### PR TITLE
Update bk4829 init to set reg 0x19 to what the stock firmware sets it to

### DIFF
--- a/App/driver/bk4829.c
+++ b/App/driver/bk4829.c
@@ -177,7 +177,7 @@ void BK4819_Init(void)
 
     BK4819_WriteRegister(0x73, 0x4691);
     BK4819_WriteRegister(0x77, 0x88EF);
-    BK4819_WriteRegister(BK4819_REG_19, 0x104E);
+    BK4819_WriteRegister(BK4819_REG_19, 0x1041);
     BK4819_WriteRegister(BK4819_REG_28, 0x0B40);
     BK4819_WriteRegister(BK4819_REG_29, 0xAA00);
     BK4819_WriteRegister(0x2A, 0x6600);


### PR DESCRIPTION
The stock UV-K1 firmware, in its initialization function, sets Register 0x19 to 0x1041 instead of the previous 0x104e. This means the last nibble is 0b1110 instead of 0b0001, which is... interesting, to say the least.

Needless to say, these bits are entirely undocumented. Bit 15, the highest bit of REG_19, controls "Automatic MIC PGA Gain Controller (MIC AGC) Disable." Namely, 1=Disable; 0=Enable. This doesn't really mean that the rest of REG_19 would control microphone stuff, though -- we have many times seen unrelated things sharing a register (AM demod, VOX, scrambler for example.) It very well might be related to the Programmable Gain Amplifier in general, which might also resolve adjacent channel selection/filtering. It's a very long shot, but it can't hurt; if the stock firmware does it this way, so should we :)

As always, I tested FM on a local repeater, but did not test for more than a day or two. Please report your findings. I never experienced the selectivity issue, so I unfortunately cannot see if it is now resolved.