### PR TITLE
feat: implement CW tail tone (MSG CW) based on power-on message

### DIFF
--- a/App/driver/bk4819.c
+++ b/App/driver/bk4819.c
@@ -26,6 +26,11 @@
 #include "driver/gpio.h"
 #include "driver/system.h"
 #include "driver/systick.h"
+#if defined(ENABLE_AIRCOPY) || defined(ENABLE_UART) || defined(ENABLE_USB)
+    #include "driver/eeprom.h"
+#else
+    #include "driver/py25q16.h"
+#endif
 
 
 #ifndef ARRAY_SIZE
@@ -1758,6 +1763,183 @@ static void BK4819_PlayRogerNormal(void)
     BK4819_WriteRegister(BK4819_REG_30, 0xC1FE);   // 1 1 0000 0 1 1111 1 1 1 0
 }
 
+static void BK4819_PlayRogerCallLn2CW(void)
+{
+    const uint8_t  cw_wpm      = 100u;
+    const uint16_t dot_ms      = (uint16_t)(1200u / cw_wpm);
+    const uint16_t dash_ms     = (uint16_t)(3u * dot_ms);
+    const uint16_t intra_ms    = dot_ms;
+    const uint16_t char_ms     = (uint16_t)(3u * dot_ms);
+    const uint16_t word_ms     = (uint16_t)(7u * dot_ms);
+    #if defined(ENABLE_AIRCOPY) || defined(ENABLE_UART) || defined(ENABLE_USB)
+        const uint16_t eep_line1   = 0x0EB0;
+        const uint16_t eep_line2   = 0x0EC0;
+    #else
+        const uint32_t line1_addr  = 0x007020;
+        const uint32_t line2_addr  = 0x007030;
+    #endif
+    const uint8_t  line_len    = 16u;
+
+    char welcome1[17];
+    char welcome2[17];
+    uint8_t i;
+
+    #if defined(ENABLE_AIRCOPY) || defined(ENABLE_UART) || defined(ENABLE_USB)
+        EEPROM_ReadBuffer(eep_line1, (uint8_t *)welcome1, line_len);
+        EEPROM_ReadBuffer(eep_line2, (uint8_t *)welcome2, line_len);
+    #else
+        PY25Q16_ReadBuffer(line1_addr, (uint8_t *)welcome1, line_len);
+        PY25Q16_ReadBuffer(line2_addr, (uint8_t *)welcome2, line_len);
+    #endif
+
+    welcome1[line_len] = '\0';
+    welcome2[line_len] = '\0';
+
+    for (i = 0; i < line_len; i++) {
+        if ((unsigned char)welcome1[i] < 0x20 || (unsigned char)welcome1[i] > 0x7E) {
+            welcome1[i] = ' ';
+        }
+        if ((unsigned char)welcome2[i] < 0x20 || (unsigned char)welcome2[i] > 0x7E) {
+            welcome2[i] = ' ';
+        }
+    }
+
+    for (i = line_len; i > 0; i--) {
+        if (welcome1[i - 1] == ' ') {
+            welcome1[i - 1] = '\0';
+        } else {
+            break;
+        }
+    }
+    for (i = line_len; i > 0; i--) {
+        if (welcome2[i - 1] == ' ') {
+            welcome2[i - 1] = '\0';
+        } else {
+            break;
+        }
+    }
+
+    {
+        uint8_t start = 0;
+        while (start < line_len && welcome1[start] == ' ') {
+            start++;
+        }
+
+        if (start > 0) {
+            uint8_t dst = 0;
+            while (welcome1[start] != '\0') {
+                welcome1[dst++] = welcome1[start++];
+            }
+            welcome1[dst] = '\0';
+        }
+    }
+
+    {
+        uint8_t start = 0;
+        while (start < line_len && welcome2[start] == ' ') {
+            start++;
+        }
+
+        if (start > 0) {
+            uint8_t dst = 0;
+            while (welcome2[start] != '\0') {
+                welcome2[dst++] = welcome2[start++];
+            }
+            welcome2[dst] = '\0';
+        }
+    }
+
+    const char *callsign = (welcome2[0] != '\0') ? welcome2 : welcome1;
+    if (callsign == NULL || callsign[0] == '\0') {
+        return;
+    }
+
+    typedef struct {
+        char        ch;
+        const char *pattern;
+    } MORSE_CHAR;
+
+    static const MORSE_CHAR morse_table[] = {
+        { 'A', ".-"      }, { 'B', "-..."    }, { 'C', "-.-."    }, { 'D', "-.."     },
+        { 'E', "."       }, { 'F', "..-."    }, { 'G', "--."     }, { 'H', "...."    },
+        { 'I', ".."      }, { 'J', ".---"    }, { 'K', "-.-"     }, { 'L', ".-.."    },
+        { 'M', "--"      }, { 'N', "-."      }, { 'O', "---"     }, { 'P', ".--."    },
+        { 'Q', "--.-"    }, { 'R', ".-."     }, { 'S', "..."     }, { 'T', "-"       },
+        { 'U', "..-"     }, { 'V', "...-"    }, { 'W', ".--"     }, { 'X', "-..-"    },
+        { 'Y', "-.--"    }, { 'Z', "--.."    },
+
+        { '0', "-----"   }, { '1', ".----"   }, { '2', "..---"   }, { '3', "...--"   },
+        { '4', "....-"   }, { '5', "....."   }, { '6', "-...."   }, { '7', "--..."   },
+        { '8', "---.."   }, { '9', "----."   },
+
+        { '/', "-..-."   }, { '?', "..--.."  }, { '=', "-...-"   }, { '+', ".-.-."   },
+    };
+    const uint8_t morse_table_size = sizeof(morse_table) / sizeof(morse_table[0]);
+
+    const uint32_t tone_Hz = 1540;
+    const uint16_t tone_reg70_value =
+        BK4819_REG_70_ENABLE_TONE1 |
+        (66u << BK4819_REG_70_SHIFT_TONE1_TUNING_GAIN);
+
+    BK4819_EnterTxMute();
+    BK4819_SetAF(BK4819_AF_MUTE);
+
+    BK4819_EnableTXLink();
+    SYSTEM_DelayMs(10);
+
+    BK4819_WriteRegister(BK4819_REG_71, scale_freq(tone_Hz));
+
+    BK4819_ExitTxMute();
+
+    const char *p = callsign;
+    while (*p != '\0') {
+        char c = *p++;
+
+        if (c == ' ') {
+            SYSTEM_DelayMs(word_ms);
+            continue;
+        }
+
+        if (c >= 'a' && c <= 'z') {
+            c -= 32;
+        }
+
+        const char *pattern = NULL;
+        for (i = 0; i < morse_table_size; i++) {
+            if (morse_table[i].ch == c) {
+                pattern = morse_table[i].pattern;
+                break;
+            }
+        }
+        if (pattern == NULL) {
+            continue;
+        }
+
+        const char *s = pattern;
+        while (*s != '\0') {
+            uint16_t on_ms = (*s == '.') ? dot_ms : dash_ms;
+
+            BK4819_WriteRegister(BK4819_REG_70, tone_reg70_value);
+            SYSTEM_DelayMs(on_ms);
+
+            BK4819_WriteRegister(BK4819_REG_70, 0x0000);
+
+            if (*(s + 1) != '\0') {
+                SYSTEM_DelayMs(intra_ms);
+            }
+
+            ++s;
+        }
+
+        SYSTEM_DelayMs(char_ms);
+    }
+
+    BK4819_EnterTxMute();
+    BK4819_WriteRegister(BK4819_REG_70, 0x0000);
+
+    BK4819_WriteRegister(BK4819_REG_30, 0xC1FE);   // 1 1 0000 0 1 1111 1 1 1 0
+}
+
 
 void BK4819_PlayRogerMDC(void)
 {
@@ -1813,6 +1995,8 @@ void BK4819_PlayRoger(void)
         BK4819_PlayRogerNormal();
     } else if (gEeprom.ROGER == ROGER_MODE_MDC) {
         BK4819_PlayRogerMDC();
+    } else if (gEeprom.ROGER == ROGER_MODE_CALL_LN2_CW) {
+        BK4819_PlayRogerCallLn2CW();
     }
 }
 

--- a/App/driver/bk4829.c
+++ b/App/driver/bk4829.c
@@ -26,6 +26,11 @@
 #include "driver/gpio.h"
 #include "driver/system.h"
 #include "driver/systick.h"
+#if defined(ENABLE_AIRCOPY) || defined(ENABLE_UART) || defined(ENABLE_USB)
+    #include "driver/eeprom.h"
+#else
+    #include "driver/py25q16.h"
+#endif
 
 
 #ifndef ARRAY_SIZE
@@ -1800,6 +1805,183 @@ static void BK4819_PlayRogerNormal(void)
     BK4819_WriteRegister(BK4819_REG_30, 0xC1FE);   // 1 1 0000 0 1 1111 1 1 1 0
 }
 
+static void BK4819_PlayRogerCallLn2CW(void)
+{
+    const uint8_t  cw_wpm      = 100u;
+    const uint16_t dot_ms      = (uint16_t)(1200u / cw_wpm);
+    const uint16_t dash_ms     = (uint16_t)(3u * dot_ms);
+    const uint16_t intra_ms    = dot_ms;
+    const uint16_t char_ms     = (uint16_t)(3u * dot_ms);
+    const uint16_t word_ms     = (uint16_t)(7u * dot_ms);
+    #if defined(ENABLE_AIRCOPY) || defined(ENABLE_UART) || defined(ENABLE_USB)
+        const uint16_t eep_line1   = 0x0EB0;
+        const uint16_t eep_line2   = 0x0EC0;
+    #else
+        const uint32_t line1_addr  = 0x007020;
+        const uint32_t line2_addr  = 0x007030;
+    #endif
+    const uint8_t  line_len    = 16u;
+
+    char welcome1[17];
+    char welcome2[17];
+    uint8_t i;
+
+    #if defined(ENABLE_AIRCOPY) || defined(ENABLE_UART) || defined(ENABLE_USB)
+        EEPROM_ReadBuffer(eep_line1, (uint8_t *)welcome1, line_len);
+        EEPROM_ReadBuffer(eep_line2, (uint8_t *)welcome2, line_len);
+    #else
+        PY25Q16_ReadBuffer(line1_addr, (uint8_t *)welcome1, line_len);
+        PY25Q16_ReadBuffer(line2_addr, (uint8_t *)welcome2, line_len);
+    #endif
+
+    welcome1[line_len] = '\0';
+    welcome2[line_len] = '\0';
+
+    for (i = 0; i < line_len; i++) {
+        if ((unsigned char)welcome1[i] < 0x20 || (unsigned char)welcome1[i] > 0x7E) {
+            welcome1[i] = ' ';
+        }
+        if ((unsigned char)welcome2[i] < 0x20 || (unsigned char)welcome2[i] > 0x7E) {
+            welcome2[i] = ' ';
+        }
+    }
+
+    for (i = line_len; i > 0; i--) {
+        if (welcome1[i - 1] == ' ') {
+            welcome1[i - 1] = '\0';
+        } else {
+            break;
+        }
+    }
+    for (i = line_len; i > 0; i--) {
+        if (welcome2[i - 1] == ' ') {
+            welcome2[i - 1] = '\0';
+        } else {
+            break;
+        }
+    }
+
+    {
+        uint8_t start = 0;
+        while (start < line_len && welcome1[start] == ' ') {
+            start++;
+        }
+
+        if (start > 0) {
+            uint8_t dst = 0;
+            while (welcome1[start] != '\0') {
+                welcome1[dst++] = welcome1[start++];
+            }
+            welcome1[dst] = '\0';
+        }
+    }
+
+    {
+        uint8_t start = 0;
+        while (start < line_len && welcome2[start] == ' ') {
+            start++;
+        }
+
+        if (start > 0) {
+            uint8_t dst = 0;
+            while (welcome2[start] != '\0') {
+                welcome2[dst++] = welcome2[start++];
+            }
+            welcome2[dst] = '\0';
+        }
+    }
+
+    const char *callsign = (welcome2[0] != '\0') ? welcome2 : welcome1;
+    if (callsign == NULL || callsign[0] == '\0') {
+        return;
+    }
+
+    typedef struct {
+        char        ch;
+        const char *pattern;
+    } MORSE_CHAR;
+
+    static const MORSE_CHAR morse_table[] = {
+        { 'A', ".-"      }, { 'B', "-..."    }, { 'C', "-.-."    }, { 'D', "-.."     },
+        { 'E', "."       }, { 'F', "..-."    }, { 'G', "--."     }, { 'H', "...."    },
+        { 'I', ".."      }, { 'J', ".---"    }, { 'K', "-.-"     }, { 'L', ".-.."    },
+        { 'M', "--"      }, { 'N', "-."      }, { 'O', "---"     }, { 'P', ".--."    },
+        { 'Q', "--.-"    }, { 'R', ".-."     }, { 'S', "..."     }, { 'T', "-"       },
+        { 'U', "..-"     }, { 'V', "...-"    }, { 'W', ".--"     }, { 'X', "-..-"    },
+        { 'Y', "-.--"    }, { 'Z', "--.."    },
+
+        { '0', "-----"   }, { '1', ".----"   }, { '2', "..---"   }, { '3', "...--"   },
+        { '4', "....-"   }, { '5', "....."   }, { '6', "-...."   }, { '7', "--..."   },
+        { '8', "---.."   }, { '9', "----."   },
+
+        { '/', "-..-."   }, { '?', "..--.."  }, { '=', "-...-"   }, { '+', ".-.-."   },
+    };
+    const uint8_t morse_table_size = sizeof(morse_table) / sizeof(morse_table[0]);
+
+    const uint32_t tone_Hz = 1540;
+    const uint16_t tone_reg70_value =
+        BK4819_REG_70_ENABLE_TONE1 |
+        (66u << BK4819_REG_70_SHIFT_TONE1_TUNING_GAIN);
+
+    BK4819_EnterTxMute();
+    BK4819_SetAF(BK4819_AF_MUTE);
+
+    BK4819_EnableTXLink();
+    SYSTEM_DelayMs(10);
+
+    BK4819_WriteRegister(BK4819_REG_71, scale_freq(tone_Hz));
+
+    BK4819_ExitTxMute();
+
+    const char *p = callsign;
+    while (*p != '\0') {
+        char c = *p++;
+
+        if (c == ' ') {
+            SYSTEM_DelayMs(word_ms);
+            continue;
+        }
+
+        if (c >= 'a' && c <= 'z') {
+            c -= 32;
+        }
+
+        const char *pattern = NULL;
+        for (i = 0; i < morse_table_size; i++) {
+            if (morse_table[i].ch == c) {
+                pattern = morse_table[i].pattern;
+                break;
+            }
+        }
+        if (pattern == NULL) {
+            continue;
+        }
+
+        const char *s = pattern;
+        while (*s != '\0') {
+            uint16_t on_ms = (*s == '.') ? dot_ms : dash_ms;
+
+            BK4819_WriteRegister(BK4819_REG_70, tone_reg70_value);
+            SYSTEM_DelayMs(on_ms);
+
+            BK4819_WriteRegister(BK4819_REG_70, 0x0000);
+
+            if (*(s + 1) != '\0') {
+                SYSTEM_DelayMs(intra_ms);
+            }
+
+            ++s;
+        }
+
+        SYSTEM_DelayMs(char_ms);
+    }
+
+    BK4819_EnterTxMute();
+    BK4819_WriteRegister(BK4819_REG_70, 0x0000);
+
+    BK4819_WriteRegister(BK4819_REG_30, 0xC1FE);   // 1 1 0000 0 1 1111 1 1 1 0
+}
+
 
 void BK4819_PlayRogerMDC(void)
 {
@@ -1855,6 +2037,8 @@ void BK4819_PlayRoger(void)
         BK4819_PlayRogerNormal();
     } else if (gEeprom.ROGER == ROGER_MODE_MDC) {
         BK4819_PlayRogerMDC();
+    } else if (gEeprom.ROGER == ROGER_MODE_CALL_LN2_CW) {
+        BK4819_PlayRogerCallLn2CW();
     }
 }
 

--- a/App/settings.c
+++ b/App/settings.c
@@ -175,7 +175,7 @@ void SETTINGS_InitEEPROM(void)
     #ifdef ENABLE_ALARM
         gEeprom.ALARM_MODE                 = (Data[0] <  2) ? Data[0] : true;
     #endif
-    gEeprom.ROGER                          = (Data[1] <  3) ? Data[1] : ROGER_MODE_OFF;
+    gEeprom.ROGER                          = (Data[1] <  4) ? Data[1] : ROGER_MODE_OFF;
     gEeprom.REPEATER_TAIL_TONE_ELIMINATION = (Data[2] < 11) ? Data[2] : 0;
     gEeprom.TX_VFO                         = (Data[3] <  2) ? Data[3] : 0;
     gEeprom.BATTERY_TYPE                   = (Data[4] < BATTERY_TYPE_UNKNOWN) ? Data[4] : BATTERY_TYPE_1600_MAH;

--- a/App/settings.h
+++ b/App/settings.h
@@ -149,7 +149,8 @@ typedef enum ALARM_Mode_t ALARM_Mode_t;
 enum ROGER_Mode_t {
     ROGER_MODE_OFF = 0,
     ROGER_MODE_ROGER,
-    ROGER_MODE_MDC
+    ROGER_MODE_MDC,
+    ROGER_MODE_CALL_LN2_CW
 };
 typedef enum ROGER_Mode_t ROGER_Mode_t;
 

--- a/App/ui/menu.c
+++ b/App/ui/menu.c
@@ -291,11 +291,12 @@ const char gSubMenu_PONMSG[][8] =
     "NONE"
 };
 
-const char gSubMenu_ROGER[][6] =
+const char gSubMenu_ROGER[][9] =
 {
     "OFF",
     "ROGER",
-    "MDC"
+    "MDC",
+    "MSG CW"
 };
 
 const char gSubMenu_RESET[][4] =

--- a/App/ui/menu.h
+++ b/App/ui/menu.h
@@ -203,7 +203,7 @@ extern const char* const gSubMenu_PTT_ID[5];
 #else
     extern const char        gSubMenu_PONMSG[4][8];
 #endif
-extern const char        gSubMenu_ROGER[3][6];
+extern const char        gSubMenu_ROGER[4][9];
 extern const char        gSubMenu_RESET[2][4];
 extern const char* const gSubMenu_F_LOCK[F_LOCK_LEN];
 extern const char        gSubMenu_RX_TX[4][6];


### PR DESCRIPTION
# Subject: New Feature: CW Tail Tone (MSG CW)

### **Developer Note**
This is a feature I previously developed for the **K5**. I would like to express my sincere gratitude to **Armel** for developing the **K1 custom firmware**, which made it possible for me to port this feature over!

---

### **Feature Description**
* A new option, **`MSG CW`**, has been added to the **Roger** (Tail Tone) settings.
* This feature automatically converts your **Power-on Greeting** (Line 2, or Line 1 if Line 2 is empty) into Morse Code (CW) and plays it at the end of each transmission.

---

### **How to Use**
1.  Enter the **`Roger`** menu (Tail Tone settings).
2.  Select the **`MSG CW`** mode.
3.  Ensure your **Power-on Greeting** (Message Line 2 or Line 1) is set to your callsign or preferred personalized text.

---

### **Key Advantages**
* **Identification:** Allows for easy operator identification during group QSOs through a unique CW signature.
* **Waveform Fingerprinting:** Although the default speed is set to **100 WPM** (too fast for most to decode by ear), the specific pattern of dots and dashes acts like a "fingerprint." It can be easily identified visually on a **spectrum waterfall** or via recorded audio waveforms.