### PR TITLE
use user permissions in docker build

### DIFF
--- a/compile-with-docker.sh
+++ b/compile-with-docker.sh
@@ -46,7 +46,9 @@ build_preset() {
   echo ""
   echo "=== 🚀 Building preset: ${preset} ==="
   echo "---------------------------------------------"
-  docker run --rm -it -v "$PWD":/src -w /src "$IMAGE" \
+  docker run --rm \
+    -u $(id -u):$(id -g) \
+    -it -v "$PWD":/src -w /src "$IMAGE" \
     bash -c "which arm-none-eabi-gcc && arm-none-eabi-gcc --version && \
              cmake --preset ${preset} ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} && \
              cmake --build --preset ${preset} -j"


### PR DESCRIPTION
Use user id in docker build. This creates the build folder with user permissions instead of root. 

`sudo ./compile-with-docker.sh Fusion` (from the second build on) is no longer needed. Simply

`./compile-with-docker.sh Fusion`

can be used.