### PR TITLE
Fix spectrum range

### DIFF
--- a/App/app/spectrum.c
+++ b/App/app/spectrum.c
@@ -1611,7 +1611,7 @@ static void UpdateScan()
 {
     Scan();
 
-    if (scanInfo.i < scanInfo.measurementsCount)
+    if (scanInfo.i + 1 < scanInfo.measurementsCount)
     {
         NextScanStep();
         return;


### PR DESCRIPTION
Hello, 

The spectrum analyser appears to scan all the frequencies according to the specified range and step size, plus one, as shown in the screenshot below where another radio transmitted on 446.20625, which is above the max. frequency : 
<img width="300" height="200" alt="image" src="https://github.com/user-attachments/assets/f6f31399-acb1-49c4-87db-acb61f5d77ca" />

Currently, we check if the current frequency is valid, then increment to the next frequency
```
if (scanInfo.i < scanInfo.measurementsCount)
{
        NextScanStep(); // increments scanInfo.i
        return;
}
```
Instead, we should check if the next frequency is valid
```
if (scanInfo.i + 1 < scanInfo.measurementsCount)
...
```

Thank you
