### PR TITLE
Fix spectrum arrow

### DIFF
--- a/App/app/spectrum.c
+++ b/App/app/spectrum.c
@@ -1432,7 +1432,7 @@ static void RenderStatus()
 static void RenderSpectrum()
 {
     DrawTicks();
-    DrawArrow(128u * peak.i / GetStepsCount());
+    DrawArrow(128u * peak.i / (GetStepsCount() - 1));
     DrawSpectrum();
     DrawRssiTriggerLevel();
     DrawF(peak.f);


### PR DESCRIPTION
Hello, 

In the spectrum analyser, the arrow indicating the position of the strongest dbm value does lag behind as the frequency increases as shown below : 

<img width="350" height="240" alt="screenshot" src="https://github.com/user-attachments/assets/bb2ffcf7-eb5f-4fa7-a444-c17f17e0a7ac" />

This is due to a recent change increasing by one the value returned by GetStepsCount(), but not making the subsequent adjustment regarding the arrow position.

We may want to use GetStepsCountDisplay() for cleaner code, but it only exists when we define _ENABLE_SCAN_RANGES_.