### PR TITLE
Fix spectrum visualisation for edge cases

### DIFF
--- a/App/app/spectrum.c
+++ b/App/app/spectrum.c
@@ -950,16 +950,16 @@ uint8_t Rssi2Y(uint16_t rssi)
                 // Total width units = (bars - 1) full bars + 2 half bars = bars
                 // First bar: half width, middle bars: full width, last bar: half width
                 // Scale: 128 pixels / (bars - 1) = pixels per full bar
-                uint16_t fullWidth = 128 * 2 / (bars - 1);  // x2 for precision
+                uint16_t fullWidth = (128 << 8) / (bars - 1);  // x256 for precision
                 
                 if (i == 0)
                 {
-                    x = fullWidth / 4;  // half of half (because fullWidth is x2)
+                    x = fullWidth / (2 << 8);  // half of /256 (because fullWidth is x256)
                 }
                 else
                 {
                     // Position = half + (i-1) full bars + current bar
-                    x = fullWidth / 4 + (uint16_t)i * fullWidth / 2;
+                    x = fullWidth / (2 << 8) + (uint16_t)i * fullWidth / (1 << 8);
                     if (i == bars - 1) x = 128;  // Last bar ends at screen edge
                 }
             }


### PR DESCRIPTION
Hello, 

When we enter the spectrum analyser with a scanrange, and the number of bars is close to "worst case" (17, 33, 65, etc.), this happens : 

<img width="300" height="200" alt="screenshot_19" src="https://github.com/user-attachments/assets/44c2eef2-195c-4880-94b5-7f182d196b91" />
<img width="300" height="200" alt="screenshot_56" src="https://github.com/user-attachments/assets/9e9e02a1-6f5a-4751-8427-5adef16fc5dc" />
<img width="300" height="200" alt="screenshot_80" src="https://github.com/user-attachments/assets/4e508ccb-0101-4bc0-86c9-1f8ebbd45420" />

While the arrow is in the correct position, the bars are clearly misplaced. Another artefact is that the very last bar will be super wide compared to the others (20-30 pixels).
To mitigate these cases, we can simply increase the precision to the maximum possible (so that it doesn't overflow).
The result is not perfect, but acceptable IMO (this is again the worst case possible) : 
<img width="300" height="200" alt="screenshot_70" src="https://github.com/user-attachments/assets/d03b0f5d-8fa3-440b-a0cb-ccf2f744e02e" />

