### PR TITLE
build: enable LTO by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,10 @@ target_link_libraries(${EXE_NAME} Core App)
 target_compile_definitions(${EXE_NAME} PRIVATE $<$<CONFIG:Debug>:DEBUG>)
 target_link_libraries(${EXE_NAME} ${TOOLCHAIN_LINK_LIBRARIES})
 
+if(ENABLE_LTO)
+    target_compile_options(${EXE_NAME} PRIVATE -flto=auto)
+endif()
+
 # Generate map file
 target_link_options(${EXE_NAME} PRIVATE "-Wl,-Map=${EXE_NAME}.map")
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,6 +9,7 @@
             "toolchainFile": "${sourceDir}/cmake/gcc-arm-none-eabi.cmake",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release",
+                "ENABLE_LTO": true,
                 "ENABLE_FMRADIO": false,
                 "ENABLE_UART": true,
                 "ENABLE_USB": true,


### PR DESCRIPTION
LTO saves ~4K in Flash and ~300 Bytes in RAM

Disable LTO
```
Memory region         Used Size  Region Size  %age Used
             RAM:       12256 B        16 KB     74.80%
           FLASH:       84304 B       118 KB     69.77%
```

Enable LTO
```
[82/82] Linking C executable f4hwn.fusion.elf
Memory region         Used Size  Region Size  %age Used
             RAM:       11904 B        16 KB     72.66%
           FLASH:       80820 B       118 KB     66.89%
```