### PR TITLE
driver: update systick to 72Mhz

### DIFF
--- a/App/driver/systick.c
+++ b/App/driver/systick.c
@@ -20,8 +20,8 @@
 static uint32_t gTickMultiplier;
 void SYSTICK_Init(void)
 {
-    SysTick_Config(480000);
-    gTickMultiplier = 48;
+    SysTick_Config(720000);
+    gTickMultiplier = 72;
     NVIC_SetPriority(SysTick_IRQn, 0);
 }
 void SYSTICK_DelayUs(uint32_t Delay)


### PR DESCRIPTION
The py32f071 that supports up to 72Mhz

I've tested on battery mode and there is no deteriorate on battery consumption.