### PR TITLE
UI improvements, backlight toggle in FM radio, code optimization

### DIFF
--- a/App/app/app.c
+++ b/App/app/app.c
@@ -1535,7 +1535,6 @@ void cancelUserInputModes(void)
         gWasFKeyPressed     = false;
         gInputBoxIndex      = 0;
         gKeyInputCountdown  = 0;
-        gBeepToPlay         = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
         gUpdateStatus       = true;
         gUpdateDisplay      = true;
     }
@@ -1558,15 +1557,13 @@ void APP_TimeSlice500ms(void)
         if (--gKeyInputCountdown == 0)
         {
 
-            if (IS_MR_CHANNEL(gTxVfo->CHANNEL_SAVE) && (gInputBoxIndex == 1 || gInputBoxIndex == 2))
+            if (IS_MR_CHANNEL(gTxVfo->CHANNEL_SAVE) && (gInputBoxIndex > 0 && gInputBoxIndex < 4))
             {
                 channelMoveSwitch();
 
                 if (gBeepToPlay == BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL) {
                     AUDIO_PlayBeep(gBeepToPlay);
                 }
-
-                SETTINGS_SaveVfoIndices();
             }
 
             cancelUserInputModes();
@@ -1936,6 +1933,7 @@ static void ProcessKey(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 
             // cancel user input
             cancelUserInputModes();
+            gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
 
             if (gMonitor)
                 ACTION_Monitor(); //turn off the monitor

--- a/App/app/fm.c
+++ b/App/app/fm.c
@@ -377,6 +377,14 @@ static void Key_FUNC(KEY_Code_t Key, uint8_t state)
                     gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
                 break;
 
+            case KEY_8:
+                ACTION_BackLightOnDemand();
+                break;
+
+            case KEY_9:
+                ACTION_BackLight();
+                break;
+
             case KEY_STAR:
                 ACTION_Scan(autoScan);
                 break;

--- a/App/app/generic.c
+++ b/App/app/generic.c
@@ -39,7 +39,7 @@
 
 void GENERIC_Key_F(bool bKeyPressed, bool bKeyHeld)
 {
-    if (gInputBoxIndex > 0) {
+    if (gInputBoxIndex > 0 || gScreenToDisplay == DISPLAY_MENU) {
         if (!bKeyHeld && bKeyPressed) // short pressed
             gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
         return;

--- a/App/app/main.c
+++ b/App/app/main.c
@@ -114,8 +114,6 @@ static void processFKeyFunction(const KEY_Code_t Key, const bool beep)
         gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
         return;
     }
-    
-    gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
 
     switch (Key) {
         case KEY_0:
@@ -212,7 +210,7 @@ static void processFKeyFunction(const KEY_Code_t Key, const bool beep)
             #endif
             COMMON_SwitchVFOMode();
             if (beep)
-                gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
+                gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
 
             break;
 
@@ -230,7 +228,7 @@ static void processFKeyFunction(const KEY_Code_t Key, const bool beep)
             break;
 
         case KEY_5:
-            if(beep) {
+            if(!beep) {
 #ifdef ENABLE_NOAA
                 if (!IS_NOAA_CHANNEL(gTxVfo->CHANNEL_SAVE)) {
                     gEeprom.ScreenChannel[Vfo] = gEeprom.NoaaChannel[gEeprom.TX_VFO];
@@ -377,6 +375,8 @@ void channelMove(uint16_t Channel)
 #endif
 
     RADIO_ConfigureChannel(gEeprom.TX_VFO, gVfoConfigureMode);
+
+    SETTINGS_SaveVfoIndices();
     
     return;
 }
@@ -411,11 +411,6 @@ void channelMoveSwitch(void) {
         if (gInputBoxIndex == 4) {
             gInputBoxIndex = 0;
             gKeyInputCountdown = 1;
-
-            channelMove(Channel - 1);
-            SETTINGS_SaveVfoIndices();
-            
-            return;
         }
 
         channelMove(Channel - 1);
@@ -436,7 +431,7 @@ static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
                 gWasFKeyPressed = false;
                 gUpdateStatus   = true;
 
-                processFKeyFunction(Key, false);
+                processFKeyFunction(Key, true);
             }
         }
         return;
@@ -682,34 +677,23 @@ static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
     }
     #endif
 
-    processFKeyFunction(Key, true);
+    processFKeyFunction(Key, false);
 }
 
 static void MAIN_Key_EXIT(bool bKeyPressed, bool bKeyHeld)
 {
     if (!bKeyHeld && bKeyPressed) { // exit key pressed
-        gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
+        gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;  // beep when key is pressed
+        return;                                 // don't use the key till it's released
+    }
 
-#ifdef ENABLE_DTMF_CALLING
-        if (gDTMF_CallState != DTMF_CALL_STATE_NONE && gCurrentFunction != FUNCTION_TRANSMIT)
-        {   // clear CALL mode being displayed
-            gDTMF_CallState = DTMF_CALL_STATE_NONE;
-            gUpdateDisplay  = true;
-            return;
-        }
-#endif
+    if (bKeyHeld) { // exit key held down
+        if (bKeyPressed) {
+            if (gInputBoxIndex > 0 || gDTMF_InputBox_Index > 0 || gDTMF_InputMode)
+            {   // cancel key input mode (channel/frequency entry)
 
-#ifdef ENABLE_FMRADIO
-        if (!gFmRadioMode)
-#endif
-        {
-            if (gScanStateDir == SCAN_OFF) {
-                if (gInputBoxIndex == 0)
-                    return;
-                gInputBox[--gInputBoxIndex] = 10;
-
-                // Restore full VFO state when back to 0
-                if (gInputBoxIndex == 0 && gHasVfoBackup) {
+                // Restore full VFO state on long press EXIT
+                if (gHasVfoBackup) {
                     const uint8_t Vfo = gEeprom.TX_VFO;
 
                     // Restore indices
@@ -727,39 +711,38 @@ static void MAIN_Key_EXIT(bool bKeyPressed, bool bKeyHeld)
                     gHasVfoBackup = false;
                 }
 
-                gKeyInputCountdown = key_input_timeout_500ms;
-                channelMoveSwitch();
-
-#ifdef ENABLE_VOICE
-                if (gInputBoxIndex == 0)
-                    gAnotherVoiceID = VOICE_ID_CANCEL;
-#endif
+                gDTMF_InputMode       = false;
+                gDTMF_InputBox_Index  = 0;
+                memset(gDTMF_String, 0, sizeof(gDTMF_String));
+                gInputBoxIndex        = 0;
+                gRequestDisplayScreen = DISPLAY_MAIN;
+                gBeepToPlay           = BEEP_1KHZ_60MS_OPTIONAL;
             }
-            else {
-                gScanKeepResult = false;
-                CHFRSCANNER_Stop();
-
-#ifdef ENABLE_VOICE
-                gAnotherVoiceID = VOICE_ID_SCANNING_STOP;
-#endif
-            }
-
-            gRequestDisplayScreen = DISPLAY_MAIN;
-            return;
         }
 
-#ifdef ENABLE_FMRADIO
-        ACTION_FM();
-#endif
         return;
     }
 
-    if (bKeyHeld && bKeyPressed) { // exit key held down
-        if (gInputBoxIndex > 0 || gDTMF_InputBox_Index > 0 || gDTMF_InputMode)
-        {   // cancel key input mode (channel/frequency entry)
+#ifdef ENABLE_DTMF_CALLING
+    if (gDTMF_CallState != DTMF_CALL_STATE_NONE && gCurrentFunction != FUNCTION_TRANSMIT)
+    {   // clear CALL mode being displayed
+        gDTMF_CallState = DTMF_CALL_STATE_NONE;
+        gUpdateDisplay  = true;
+        return;
+    }
+#endif
 
-            // Restore full VFO state on long press EXIT
-            if (gHasVfoBackup) {
+#ifdef ENABLE_FMRADIO
+    if (!gFmRadioMode)
+#endif
+    {
+        if (gScanStateDir == SCAN_OFF) {
+            if (gInputBoxIndex == 0)
+                return;
+            gInputBox[--gInputBoxIndex] = 10;
+
+            // Restore full VFO state when back to 0
+            if (gInputBoxIndex == 0 && gHasVfoBackup) {
                 const uint8_t Vfo = gEeprom.TX_VFO;
 
                 // Restore indices
@@ -777,14 +760,31 @@ static void MAIN_Key_EXIT(bool bKeyPressed, bool bKeyHeld)
                 gHasVfoBackup = false;
             }
 
-            gDTMF_InputMode       = false;
-            gDTMF_InputBox_Index  = 0;
-            memset(gDTMF_String, 0, sizeof(gDTMF_String));
-            gInputBoxIndex        = 0;
-            gRequestDisplayScreen = DISPLAY_MAIN;
-            gBeepToPlay           = BEEP_1KHZ_60MS_OPTIONAL;
+            gKeyInputCountdown = key_input_timeout_500ms;
+            channelMoveSwitch();
+
+#ifdef ENABLE_VOICE
+            if (gInputBoxIndex == 0)
+                gAnotherVoiceID = VOICE_ID_CANCEL;
+#endif
         }
+        else {
+            gScanKeepResult = false;
+            CHFRSCANNER_Stop();
+
+#ifdef ENABLE_VOICE
+            gAnotherVoiceID = VOICE_ID_SCANNING_STOP;
+#endif
+        }
+
+        gRequestDisplayScreen = DISPLAY_MAIN;
+        return;
     }
+
+#ifdef ENABLE_FMRADIO
+    ACTION_FM();
+#endif
+    return;
 }
 
 static void MAIN_Key_MENU(bool bKeyPressed, bool bKeyHeld)
@@ -837,6 +837,9 @@ static void MAIN_Key_MENU(bool bKeyPressed, bool bKeyHeld)
     }
 
     if (!bKeyPressed && !gDTMF_InputMode) { // menu key released
+        gKeyInputCountdown = 1;
+        channelMoveSwitch();
+
         const bool bFlag = !gInputBoxIndex;
         gInputBoxIndex   = 0;
 
@@ -985,7 +988,7 @@ static void MAIN_Key_UP_DOWN(bool bKeyPressed, bool bKeyHeld, int8_t Direction)
 
     if (bKeyHeld || !bKeyPressed) { // key held or released
         if (gInputBoxIndex > 0)
-            return; // leave if input box active
+            gInputBoxIndex = 0;
 
         if (!bKeyPressed) {
             if (!bKeyHeld || IS_FREQ_CHANNEL(Channel))
@@ -999,10 +1002,6 @@ static void MAIN_Key_UP_DOWN(bool bKeyPressed, bool bKeyHeld, int8_t Direction)
         }
     }
     else { // short pressed
-        if (gInputBoxIndex > 0) {
-            gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
-            return;
-        }
         gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
     }
 


### PR DESCRIPTION
Hello. I got my hands on a Quansheng UV-K5 V3 and I am very happy with it. I decided to make the same changes and repairs that were needed on the old device (https://github.com/armel/uv-k5-firmware-custom/pull/535), and I found one error that only occurs on the new version.

# Changes and errors in the old and new Quansheng

## Fixed incorrect beeps after channel change

Resolved an issue where pressing [KEY_SIDE1], [KEY_SIDE2], or [* SCAN] immediately after confirming a channel input with timeout in MR mode would play an error beep followed by a confirmation beep.

> 1. Enter the channel number in MR mode.
> 2. Wait for channel confirm (timeout).
> 3. Press \[KEY\_SIDE1], \[KEY\_SIDE2], or \[\* SCAN].

## Fixed VFO/MR toggle sound

Changing the VFO/MR mode (F+3) now correctly plays a confirmation beep instead of an error beep.

## Added error beep in MENU when attempting to use the function key.

Pressing the function key [F#] while inside the MENU (except when inputting a name in [ChName, etc.]) will now correctly play an error beep to indicate an invalid action. Previously, an error beep was played when a single digit was entered (a confirmation beep was played for a two-digit number).

> 1. Press MENU to enter settings.
> 2. Press \[F#] - a confirmation beep will play.
> 3. Enter any digit (1-9).
> 4. Press \[F#] - a error beep will play.
> 5. Enter any digit again (for a two-digit position in the settings).
> 6. Press \[F#] - a confirmation beep will play.

## Removed double playback of confirmation beep when using a function key with a number.

Previously, pressing the [F#] function key with a number played the sound twice. Now the sound plays once.

## Added the ability to change channels using the arrow keys when changing channels using numbers.

I once suggested this change, but it was rejected. I think it's quite a useful feature that improves navigation within the channel. For example, if a user makes a mistake when entering a channel, they can use the arrows to quickly correct the error. Otherwise, they would have to wait for the channel to be approved.

>1. Enter the channel number in MR mode.
>2. Use the up/down arrows. The channel will be changed and the input mode will be canceled.

## Added manual backlight control in FM radio mode.

In FM radio mode, the [F+8] and [F+9] functions are not used, so I came up with the idea of enabling manual control of the backlight.

>1. Enter FM radio mode.
>2. Try using \[F+8] or \[F+9].

## Removed redundant SETTINGS_SaveVfoIndices() from APP_TimeSlice500ms(void)

Removed redundant SETTINGS_SaveVfoIndices() from APP_TimeSlice500ms(void) because it is not needed (SETTINGS_SaveVfoIndices() is in the ChannelMove() function, and ChannelMove() is executed in APP_TimeSlice500ms(void)).

# Error occurring only in the new Quansheng UVK1 / K5v3

## Fixed a bug with no error beep for three-digit channel numbers.

When changing channels (using numbers) that do not exist and are three digits long, no error beep was played.
---
**I hope I have been helpful and that my suggestions will be accepted. I look forward to hearing your opinion.**

Modified code: https://github.com/mrkusypl/uv-k1-k5v3-firmware-custom/commit/793a44855d7dd3366683b78ae3ba2588e3a01552