### PR TITLE
Add spectrum channel mode (from #98)

### DIFF
--- a/App/app/spectrum.c
+++ b/App/app/spectrum.c
@@ -59,6 +59,7 @@ bool newScanStart = true;
 bool preventKeypress = true;
 bool audioState = true;
 bool lockAGC = false;
+bool isChMode = false;
 
 State currentState = SPECTRUM, previousState = SPECTRUM;
 
@@ -174,6 +175,11 @@ KEY_Code_t freqInputArr[10];
 char freqInputString[11];
 
 uint8_t menuState = 0;
+uint8_t currentSL = 0;
+uint8_t countSLchannels = 0;
+uint16_t firstChannel = 0, lastChannel = 0;
+uint16_t currentSLchannel = 0;
+FREQUENCY_Band_t slBand = 0;
 uint16_t listenT = 0;
 
 RegisterSpec registerSpecs[] = {
@@ -278,7 +284,7 @@ static uint8_t DBm2S(int dbm)
 
 static int Rssi2DBm(uint16_t rssi)
 {
-    return (rssi / 2) - 160 + dBmCorrTable[gRxVfo->Band];
+    return (rssi / 2) - 160 + dBmCorrTable[isChMode? slBand : gRxVfo->Band];
 }
 
 static uint16_t GetRegMenuValue(uint8_t st)
@@ -521,7 +527,7 @@ static void ResetPeak()
     }
 #endif
 
-bool IsCenterMode() { return settings.scanStepIndex < S_STEP_2_5kHz; }
+bool IsCenterMode() { return settings.scanStepIndex < S_STEP_2_5kHz && !isChMode; }
 // scan step in 0.01khz
 uint16_t GetScanStep() { return scanStepValues[settings.scanStepIndex]; }
 
@@ -535,7 +541,7 @@ uint16_t GetStepsCount()
         return (range / step) + 1;  // +1 to include up limit
     }
 #endif
-    return 128 >> settings.stepsCount;
+    return isChMode? scanInfo.measurementsCount : 128 >> settings.stepsCount;
 }
 
 #ifdef ENABLE_SCAN_RANGES
@@ -552,6 +558,12 @@ static uint16_t GetStepsCountDisplay()
 uint32_t GetBW() { return GetStepsCount() * GetScanStep(); }
 uint32_t GetFStart()
 {
+    if (isChMode)
+    {
+        uint32_t ret, base = firstChannel * 16;
+        PY25Q16_ReadBuffer(base, &ret, sizeof(ret));
+        return ret;
+    }
     return IsCenterMode() ? currentFreq - (GetBW() >> 1) : currentFreq;
 }
 
@@ -563,6 +575,12 @@ uint32_t GetFEnd()
         return gScanRangeStop;
     }
 #endif
+    if (isChMode)
+    {
+        uint32_t ret, base = lastChannel * 16;
+        PY25Q16_ReadBuffer(base, &ret, sizeof(ret));
+        return ret;
+    }
     return currentFreq + GetBW();
 }
 
@@ -664,6 +682,28 @@ static void ToggleRX(bool on)
     }
 }
 
+void getScanlistInfo(uint8_t scanlist, uint8_t recursive, bool inc)
+{
+    if(!recursive)
+        return;
+    firstChannel = RADIO_FindNextChannel(0, 1, true, scanlist);
+    lastChannel = RADIO_FindNextChannel(0xFFFF, -1, true, scanlist);
+    uint16_t channel = firstChannel;
+    countSLchannels = 0;
+    do
+        channel = RADIO_FindNextChannel(channel + 1, 1, true, scanlist);
+    while (++countSLchannels && channel != firstChannel);
+    if(firstChannel == 0xFFFF)
+        getScanlistInfo(inc? (scanlist >= MR_CHANNELS_LIST ? 1 : scanlist + 1) : (scanlist <= 1? MR_CHANNELS_LIST : scanlist - 1), recursive - 1, inc);
+    else 
+    {
+        currentSL = scanlist;
+        uint32_t base = firstChannel * 16;
+        PY25Q16_ReadBuffer(base, &initialFreq, sizeof(initialFreq));
+        slBand = FREQUENCY_GetBand(initialFreq);
+    }
+}
+
 // Scan info
 
 static void ResetScanStats()
@@ -708,6 +748,12 @@ static void InitScanPosition()
         scanInfo.f = GetFStart();
         scanForward = true;
     }
+    if (isChMode)
+    {
+        currentSLchannel = scanForward? firstChannel:lastChannel;
+        scanInfo.measurementsCount = countSLchannels;
+    }
+    
     scanReturnPending = scanInfo.measurementsCount > 1;
 }
 
@@ -953,7 +999,7 @@ static void ResetSpectrumToDefaults()
 
 static uint16_t dbm2rssi(int dBm)
 {
-    return (dBm + 160 - dBmCorrTable[gRxVfo->Band]) * 2;
+    return (dBm + 160 - dBmCorrTable[isChMode? slBand : gRxVfo->Band]) * 2;
 }
 
 static void ClampRssiTriggerLevel()
@@ -1666,12 +1712,25 @@ static void DrawNums()
         sprintf(String, "%ux", GetStepsCount());
 #endif
         GUI_DisplaySmallest(String, 0, 1, false, true);
-        sprintf(String, "%u.%02uk", GetScanStep() / 100, GetScanStep() % 100);
+        if(isChMode) 
+        {
+            const char *name = gListName[currentSL - 1]; // from App/ui/status.c
+            bool nameValid = (name[0] != '\0' && name[0] != '\xff' && name[0] != ' ');
+            if (!nameValid) 
+                sprintf(String, "List %02d", currentSL);
+            else sprintf(String, "List %.3s", name);
+        }
+        else sprintf(String, "%u.%02uk", GetScanStep() / 100, GetScanStep() % 100);
         GUI_DisplaySmallest(String, 0, 7, false, true);
 
     }
 
-    if (IsCenterMode())
+    if (isChMode)
+    {
+        sprintf(String, "Channel mode");
+        GUI_DisplaySmallest(String, 40, 49, false, true);
+    }
+    else if (IsCenterMode())
     {
         sprintf(String, "%u.%05u \x7F%u.%02uk", currentFreq / 100000,
                 currentFreq % 100000, settings.frequencyChangeStep / 100,
@@ -1755,6 +1814,8 @@ static void DrawRssiTriggerLevel(const uint8_t *topY)
 
 static void DrawTicks()
 {
+    if(isChMode)
+        return;
     uint32_t f = GetFStart();
     uint32_t span = GetFEnd() - GetFStart();
     uint32_t step = span / 128;
@@ -1842,7 +1903,15 @@ static void OnKeyDown(uint8_t key) {
         break;
     case KEY_2:
     case KEY_8:
-        UpdateFreqChangeStep(isTrue);
+        if(isChMode)
+        {
+            isTrue? getScanlistInfo(currentSL >= MR_CHANNELS_LIST? 1 : currentSL + 1, MR_CHANNELS_LIST + 1, true) :
+                    getScanlistInfo(currentSL <= 1? MR_CHANNELS_LIST : currentSL - 1, MR_CHANNELS_LIST + 1, false);
+            RelaunchScan();
+            ResetBlacklist();
+            redrawScreen = true;
+        }
+        else UpdateFreqChangeStep(isTrue);
         break;
     case KEY_UP:
     case KEY_DOWN:
@@ -1853,7 +1922,7 @@ static void OnKeyDown(uint8_t key) {
             break;
         }
 #ifdef ENABLE_SCAN_RANGES
-        if (!gScanRangeStart) {
+        if (!gScanRangeStart && !isChMode) {
 #endif
         UpdateCurrentFreq(GetDirection(key));
 #ifdef ENABLE_SCAN_RANGES
@@ -1865,13 +1934,13 @@ static void OnKeyDown(uint8_t key) {
         break;
     case KEY_5:
 #ifdef ENABLE_SCAN_RANGES
-        if (!gScanRangeStart)
+        if (!gScanRangeStart && !isChMode)
 #endif
             FreqInput();
         break;
     case KEY_4:
 #ifdef ENABLE_SCAN_RANGES
-        if (!gScanRangeStart)
+        if (!gScanRangeStart && !isChMode)
 #endif
             ToggleStepsCount();
         break;
@@ -2207,10 +2276,22 @@ static void NextScanStep()
     ++peak.t;
     if (scanForward) {
         ++scanInfo.i;
-        scanInfo.f += scanInfo.scanStep;
+        if (isChMode)
+        {
+            currentSLchannel = RADIO_FindNextChannel(currentSLchannel + 1, 1, true, currentSL);
+            uint32_t base = currentSLchannel * 16;
+            PY25Q16_ReadBuffer(base, &scanInfo.f, sizeof(scanInfo.f));
+        }
+        else scanInfo.f += scanInfo.scanStep;
     } else {
         --scanInfo.i;
-        scanInfo.f -= scanInfo.scanStep;
+        if (isChMode)
+        {
+            currentSLchannel = RADIO_FindNextChannel(currentSLchannel - 1, -1, true, currentSL);
+            uint32_t base = currentSLchannel * 16;
+            PY25Q16_ReadBuffer(base, &scanInfo.f, sizeof(scanInfo.f));
+        }
+        else scanInfo.f -= scanInfo.scanStep;
     }
 }
 
@@ -2228,7 +2309,14 @@ static bool NextScanStepInterlaced()
     if (next < scanInfo.measurementsCount)
     {
         scanInfo.i = next;
-        scanInfo.f += (uint32_t)interlaceStride * scanInfo.scanStep;
+        if (isChMode)
+        {
+            for (uint16_t i = 0; i < interlaceStride; i++)
+                currentSLchannel = RADIO_FindNextChannel(currentSLchannel + 1, 1, true, currentSL);
+            uint32_t base = currentSLchannel * 16;
+            PY25Q16_ReadBuffer(base, &scanInfo.f, sizeof(scanInfo.f));
+        }
+        else scanInfo.f += (uint32_t)interlaceStride * scanInfo.scanStep;
         return false;
     }
 
@@ -2238,7 +2326,14 @@ static bool NextScanStepInterlaced()
         {
             interlacePhase = phase;
             scanInfo.i = phase;
-            scanInfo.f = GetFStart() + (uint32_t)phase * scanInfo.scanStep;
+            if (isChMode)
+            {
+                for (uint16_t i = 0; i < phase; i++)
+                    currentSLchannel = RADIO_FindNextChannel(currentSLchannel + 1, 1, true, currentSL);
+                uint32_t base = currentSLchannel * 16;
+                PY25Q16_ReadBuffer(base, &scanInfo.f, sizeof(scanInfo.f));
+            }
+            else scanInfo.f = GetFStart() + (uint32_t)phase * scanInfo.scanStep;
             return false;
         }
     }
@@ -2561,9 +2656,17 @@ void APP_RunSpectrum()
 #ifdef ENABLE_FEAT_F4HWN_SPECTRUM
     LoadSettings();
 #endif
+    isChMode = false;
+    countSLchannels = 0;
+    currentSL = MIN(gTxVfo->SCANLIST_PARTICIPATION, MR_CHANNELS_LIST);
+    if(IS_MR_CHANNEL(gTxVfo->CHANNEL_SAVE) && currentSL)
+    {
+        isChMode = true;
+        getScanlistInfo(currentSL, MR_CHANNELS_LIST + 1, true);
+    }
     // set the current frequency in the middle of the display
 #ifdef ENABLE_SCAN_RANGES
-    if (gScanRangeStart)
+    else if (gScanRangeStart)
     {
         currentFreq = initialFreq = gScanRangeStart;
         // Keep saved spectrum step/count in scan-range mode.


### PR DESCRIPTION
Hello, 

A small rework of #98 to add a channel mode in the spectrum analyser. 

> While reading the discussion started by @jaap59, i thought it might be interesting to propose a channel mode in the spectrum analyser, which would allow for a faster scan of stored channels. It may be useful for channel groups which share the same band but are not contiguous (GMRS). However, this comes with many issues.

> As implemented, it allows for the scan of memory channels in scanlists 1-**24**, with the F + 5 key combination when in channel mode. Once in the spectrum analyser, the user can press left/right to go through scanlists.
It does not look for different modulation types, different bands or bandwidth (so it is not for people mixing AM and FM channels in the same scanlist, and there is no adequate dbm correction if channels have a different freq. band).

> What do y'all think?

Note that it introduces an array of frequencies _chFreqs_ that currently takes 512 bytes of sram.

Thank you

EDIT : the display of the scanlist name is untested 