### PR TITLE
Bug fixes: Receiving the same channel in Dual Watch mode, disabling channel exclusion, changing the scan list, compilation error

### DIFF
--- a/App/app/main.c
+++ b/App/app/main.c
@@ -75,9 +75,10 @@ static void toggle_chan_scanlist(void)
     if(att->exclude == true)
     {
         att->exclude = false;
-        return;
+        MR_SaveChannelAttributesToFlash(gTxVfo->CHANNEL_SAVE, att);
     } 
-
+    else 
+    {
         uint8_t scanlist = gTxVfo->SCANLIST_PARTICIPATION;
 
         scanlist++;
@@ -88,6 +89,7 @@ static void toggle_chan_scanlist(void)
         gTxVfo->SCANLIST_PARTICIPATION = scanlist;
 
         SETTINGS_UpdateChannel(gTxVfo->CHANNEL_SAVE, gTxVfo, true, true, true);
+    }
 
     gVfoConfigureMode = VFO_CONFIGURE;
     gFlagResetVfos    = true;
@@ -483,27 +485,21 @@ static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
             /* 01 .. MR_CHANNELS_LIST */
             if (value <= MR_CHANNELS_LIST)
             {
-                if (RADIO_CheckValidList(value))
+                gEeprom.SCAN_LIST_DEFAULT = value;
+
+                if (!RADIO_CheckValidList(value))
                 {
-                    /* Requested scan list is valid */
-            gEeprom.SCAN_LIST_DEFAULT = value;
+                    /* Requested scan list is empty or invalid:
+                        jump to the next valid scan list */
+                    gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
+                    RADIO_NextValidList(1);
                 }
-                else
-            {
-                /* Requested scan list is empty or invalid:
-                    jump to the next valid scan list */
-                    gEeprom.SCAN_LIST_DEFAULT = value;
-                RADIO_NextValidList(1);
-            }
 
             #ifdef ENABLE_FEAT_F4HWN_RESUME_STATE
                 SETTINGS_WriteCurrentState();
             #endif
             }
 
-            gInputBoxIndex = 0;
-
-            gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
             return;
         }
 
@@ -763,6 +759,7 @@ static void MAIN_Key_EXIT(bool bKeyPressed, bool bKeyHeld)
         }
         else {
             gScanKeepResult = false;
+            gInputBoxIndex = 0;
             CHFRSCANNER_Stop();
 
 #ifdef ENABLE_VOICE

--- a/App/misc.c
+++ b/App/misc.c
@@ -293,7 +293,7 @@ uint8_t           gFSKWriteIndex;
 
 #ifdef ENABLE_NOAA
     bool          gIsNoaaMode;
-    uint16_t      gNoaaChannel;
+    uint8_t      gNoaaChannel;
 #endif
 
 bool              gUpdateDisplay;

--- a/App/ui/main.c
+++ b/App/ui/main.c
@@ -768,22 +768,23 @@ void UI_DisplayMain(void)
         {   // receiving .. show the RX symbol
             mode = VFO_MODE_RX;
             //if (FUNCTION_IsRx() && gEeprom.RX_VFO == vfo_num) {
-            if (FUNCTION_IsRx() && gEeprom.RX_VFO == vfo_num && VfoState[vfo_num] == VFO_STATE_NORMAL) {
+            if (FUNCTION_IsRx()) {
+                if (gEeprom.RX_VFO == vfo_num && VfoState[vfo_num] == VFO_STATE_NORMAL) {
 #ifdef ENABLE_FEAT_F4HWN
                     RxBlinkLed = 1;
                     RxBlinkLedCounter = 0;
                     RxLine = line;
                     RxOnVfofrequency = frequency;
-                // if(!isMainVFO)
-                // {
-                //     RxBlink = 1;
-                // }
-                // else
-                // {
-                //     RxBlink = 0;
-                // }
+                    // if(!isMainVFO)
+                    // {
+                    //     RxBlink = 1;
+                    // }
+                    // else
+                    // {
+                    //     RxBlink = 0;
+                    // }
 
-                // if (RxBlink == 0 || RxBlink == 1) {
+                    // if (RxBlink == 0 || RxBlink == 1) {
                         if(gRxVfo->Modulation == MODULATION_AM)
                             GUI_DisplaySmallest("AIR", 10, RxLine == 0 ? 1 : 33, false, true);
                         else {
@@ -796,16 +797,19 @@ void UI_DisplayMain(void)
                         }
 
                         //UI_PrintStringSmallBold("RX", 8, 0, RxLine);
-                // }
+                    // }
 #else
                     UI_PrintStringSmallBold("RX", 8, 0, line);
 #endif
                 }
 #ifdef ENABLE_FEAT_F4HWN
-            else
-            {
-                if(RxOnVfofrequency == frequency && !isMainOnly())
-                {
+                else {
+                    if(RxBlinkLed == 1)
+                        RxBlinkLed = 2;
+                }
+            }
+            else {
+                if(RxOnVfofrequency == frequency && !isMainOnly()) {
                     //UI_PrintStringSmallNormal(">>", 8, 0, line);
                     //memcpy(p_line0 + 14, BITMAP_VFO_Default, sizeof(BITMAP_VFO_Default));
                     GUI_DisplaySmallest(">>", 8, RxLine == 0 ? 1 : 33, false, true);


### PR DESCRIPTION
**Hello. I am creating this pull request to include bug fixes from the previous pull request and new bug fixes.**

# Bug fixes from the previous pull request

## Removed the error beep for the correct scan lists.

I have fixed the issue where selecting an existing scan list with assigned channels would trigger an error beep (except for ALL). Now, selecting a valid scan list should not trigger an error beep, and selecting a empty list will trigger an error.

## Removed the error exiting scan during input

The error is related to the fact that when we enter the first digit in scan mode, pressing EXIT gInputBoxIndex will remain active - now it should be set to 0.

## Minor refactoring of the conditional statement.

I have slightly modified the conditional statement in the scan list selection logic. I moved "gEeprom.SCAN_LIST_DEFAULT = value" outside the condition to eliminate redundancy. The change does not alter the size of the code.

# New bug fixes

## Fixed a graphical bug related to receiving the same channel in DW mode.

The point is that if memory A and memory B contain the same channels and the DWR, DW, and XB modes are set,  the double arrow overlaps with the audio profile name, as shown in the screenshot below:

<details>
  <summary>Screenshot</summary><img width="704" height="384" alt="screenshot before" src="https://github.com/user-attachments/assets/53a1c180-85ea-4152-8d08-5e8316326094" />
</details>

Now it should look like this:

<details>
  <summary>Screenshot</summary><img width="704" height="384" alt="screenshot after" src="https://github.com/user-attachments/assets/21f5e55e-aa3d-48fe-8561-bf22ca2e8091" />
</details>

...and double arrows should appear after RX stops.

## Fixed a bug related to excluding channels from scanning

Previously, when we excluded a channel during scanning, we could undo the exclusion - but it didn't work. After undoing the exclusion, the EX mark disappeared, but after changing the channel and returning, the mark reappeared. Now it should work correctly.

## Error during compilation with the RescueOps preset

A small mistake - all I had to do was change the type of the gNoaaChannel variable. Simple.