### PR TITLE
Backlight fading and improved backlight control in spectrum

### DIFF
--- a/App/app/app.c
+++ b/App/app/app.c
@@ -1358,9 +1358,9 @@ void APP_TimeSlice10ms(void)
 {
     gNextTimeslice = false;
 
-    if (gScheduleVfoSave) {
-        SETTINGS_SaveVfoIndicesFlush();
-    }
+    SETTINGS_SaveVfoIndicesFlush();
+
+    BACKLIGHT_Update();
 
     gFlashLightBlinkCounter++;
 

--- a/App/app/breakout.c
+++ b/App/app/breakout.c
@@ -461,6 +461,9 @@ void APP_RunBreakout(void) {
         // Init led
         BK4819_ToggleGpioOut(BK4819_GPIO6_PIN2_GREEN, false);
 
+        // Finish the brightness fade if it is in progress
+        BACKLIGHT_UpdateTickless();
+
         // Init game
         UI_DisplayClear();
         reset();

--- a/App/app/spectrum.c
+++ b/App/app/spectrum.c
@@ -787,11 +787,13 @@ static void ToggleBacklight()
     settings.backlightState = !settings.backlightState;
     if (settings.backlightState)
     {
-        BACKLIGHT_TurnOn();
+        // BACKLIGHT_TurnOn();
+        BACKLIGHT_SetBrightness(gEeprom.BACKLIGHT_MAX);
     }
     else
     {
-        BACKLIGHT_TurnOff();
+        // BACKLIGHT_TurnOff();
+        BACKLIGHT_SetBrightness(gEeprom.BACKLIGHT_MIN);
     }
 }
 
@@ -1665,16 +1667,17 @@ static void UpdateListening()
 
 static void Tick()
 {
-#ifdef ENABLE_AM_FIX
     if (gNextTimeslice)
     {
         gNextTimeslice = false;
+#ifdef ENABLE_AM_FIX
         if (settings.modulationType == MODULATION_AM && !lockAGC)
         {
             AM_fix_10ms(vfo); // allow AM_Fix to apply its AGC action
         }
-    }
 #endif
+        BACKLIGHT_Update();
+    }
 
 #ifdef ENABLE_SCAN_RANGES
     if (gNextTimeslice_500ms)
@@ -1742,6 +1745,8 @@ static void Tick()
 
 void APP_RunSpectrum()
 {
+    settings.backlightState = gEeprom.BACKLIGHT_TIME == 0 ? false : true;
+
     // TX here coz it always? set to active VFO
     vfo = gEeprom.TX_VFO;
 #ifdef ENABLE_FEAT_F4HWN_SPECTRUM
@@ -1804,4 +1809,6 @@ void APP_RunSpectrum()
     {
         Tick();
     }
+
+    BACKLIGHT_TurnOn();
 }

--- a/App/driver/backlight.c
+++ b/App/driver/backlight.c
@@ -44,7 +44,13 @@ static uint32_t dutyCycle[DUTY_CYCLE_LEVELS];
 
 // this is decremented once every 500ms
 uint16_t gBacklightCountdown_500ms = 0;
+bool gUpdateBacklight = false;
 bool backlightOn;
+
+static uint8_t currentIndex = 0;
+static int16_t currentBrightness = 0;
+static int16_t targetBrightness = 0;
+static int16_t fadeStep = 0;
 
 #ifdef ENABLE_FEAT_F4HWN
     const uint8_t value[] = {
@@ -110,6 +116,12 @@ static void BACKLIGHT_Sound(void)
     gK5startup = false;
 }
 
+void BACKLIGHT_UpdateTickless(void) {
+    while(gUpdateBacklight) {
+        BACKLIGHT_Update();
+        SYSTEM_DelayMs(10);
+    }
+}
 
 void BACKLIGHT_TurnOn(void)
 {
@@ -134,27 +146,23 @@ void BACKLIGHT_TurnOn(void)
 
     backlightOn = true;
 
-#ifdef ENABLE_FEAT_F4HWN
-    if(gK5startup == true) {
-        #if defined(ENABLE_FMRADIO) && defined(ENABLE_SPECTRUM)
-            BACKLIGHT_SetBrightness(gEeprom.BACKLIGHT_MAX);
-        #else
-            for(uint8_t i = 0; i <= gEeprom.BACKLIGHT_MAX; i++)
-            {
-                BACKLIGHT_SetBrightness(i);
-                SYSTEM_DelayMs(50);
-            }
-        #endif
-
-        BACKLIGHT_Sound();
-    }
-    else
-    {
-        BACKLIGHT_SetBrightness(gEeprom.BACKLIGHT_MAX);
-    }
-#else
     BACKLIGHT_SetBrightness(gEeprom.BACKLIGHT_MAX);
+
+#ifdef ENABLE_FEAT_F4HWN
+    if(gK5startup == true)
+#else
+    static bool startup = true;
+    
+    if(startup)
 #endif
+    {
+        BACKLIGHT_UpdateTickless();
+#ifdef ENABLE_FEAT_F4HWN
+        BACKLIGHT_Sound();
+#else
+        startup = false;
+#endif
+    }
 
     switch (gEeprom.BACKLIGHT_TIME) {
         default:
@@ -190,18 +198,11 @@ bool BACKLIGHT_IsOn()
     return backlightOn;
 }
 
-static uint8_t currentBrightness = 0;
-
-void BACKLIGHT_SetBrightness(uint8_t brigtness)
+static void BACKLIGHT_SetHardwareBrightness(uint8_t brightness)
 {
     // printf("BL: %d\n", brigtness);
 
-    if (currentBrightness == brigtness)
-    {
-        return;
-    }
-
-    if (0 == brigtness)
+    if (0 == brightness)
     {
         LL_TIM_DisableCounter(TIMx);
         LL_DMA_DisableChannel(DMA1, DMA_CHANNEL);
@@ -210,7 +211,7 @@ void BACKLIGHT_SetBrightness(uint8_t brigtness)
     }
     else
     {
-        const uint32_t level = (uint32_t)(value[brigtness]) * DUTY_CYCLE_LEVELS / 255;
+        const uint32_t level = (uint32_t)(brightness) * DUTY_CYCLE_LEVELS / 255;
         if (level >= DUTY_CYCLE_LEVELS)
         {
             LL_TIM_DisableCounter(TIMx);
@@ -231,11 +232,45 @@ void BACKLIGHT_SetBrightness(uint8_t brigtness)
             }
         }
     }
+}
 
-    currentBrightness = brigtness;
+void BACKLIGHT_Update(void)
+{
+    if (gUpdateBacklight) {
+        currentBrightness += fadeStep;
+
+        if ((fadeStep > 0 && currentBrightness >= targetBrightness) || 
+            (fadeStep < 0 && currentBrightness <= targetBrightness)) {
+            currentBrightness = targetBrightness;
+            gUpdateBacklight = false;
+        }
+
+        BACKLIGHT_SetHardwareBrightness((uint8_t)currentBrightness);
+    }
+}
+
+void BACKLIGHT_SetBrightness(uint8_t targetIndex)
+{
+    if (currentIndex == targetIndex) {
+        return;
+    }
+
+    currentIndex = targetIndex;
+    targetBrightness = value[targetIndex];
+
+    int16_t diff = targetBrightness - currentBrightness;
+
+    if (diff == 0) {
+        gUpdateBacklight = false;
+        return;
+    }
+    
+    fadeStep = diff > 0 ? -(-diff >> 4) : diff >> 4;
+
+    gUpdateBacklight = true;
 }
 
 uint8_t BACKLIGHT_GetBrightness(void)
 {
-    return currentBrightness;
+    return currentIndex;
 }

--- a/App/driver/backlight.h
+++ b/App/driver/backlight.h
@@ -40,10 +40,12 @@ typedef enum {
 #endif
 
 void BACKLIGHT_InitHardware();
+void BACKLIGHT_UpdateTickless(void);
 void BACKLIGHT_TurnOn();
 void BACKLIGHT_TurnOff();
 bool BACKLIGHT_IsOn();
 void BACKLIGHT_SetBrightness(uint8_t brigtness);
+void BACKLIGHT_Update(void);
 uint8_t BACKLIGHT_GetBrightness(void);
 
 #endif


### PR DESCRIPTION
### Hello

I am pleased to present the feature (or gimmick) that I announced a week ago in the discussion (https://github.com/armel/uv-k1-k5v3-firmware-custom/discussions/185) - backlight fading.

The most difficult task was deciding how to implement this function. The first prototype I showed in my first post in the discussion was based on while loops. Implementation based on while loops was the simplest, but it had one drawback that bothered me - it blocked other radio tasks for the entire duration of the loop.

I decided to replace the while loop with a better, but more difficult solution - basing the effect on APP_TimeSlice10ms() - thanks to which the effect did not block other tasks and, if necessary, could change the direction of brightening/dimming, e.g. if the user pressed a button while the screen was fading out, the screen would brighten.

Why is the solution based on APP_TimeSlice10ms() more difficult? The reason is that this function only starts executing after the welcome screen is displayed, and the function stops executing in spectrum and the Breakout game. In spectrum, it was necessary to add separate logic for updating the backlight every 10 ms, and when starting the radio and the game, a while loop is executed where “asynchronous” is not necessary.

I also fixed a bug where setting BLTime to OFF prevented the backlight from being temporarily turned on in the spectrum, and corrected the backlight flag setting when entering the spectrum. In addition, I made a small code optimization in one place, where the function was executed if the flag is true, and within this function there is a recheck to see if the function is true.

---

The end result is phenomenal. I tested all the places where brightness changes (settings, spectrum, pressing keys, end of transmission, deep sleep, etc.). I am waiting for feedback - it is worth testing it out for yourself to see how it works.