### PR TITLE
Fix for the Audio Scope in OnePush mode

### DIFF
--- a/App/ui/main.c
+++ b/App/ui/main.c
@@ -265,6 +265,9 @@ void UI_DisplayAudioScope(void)
 #ifdef ENABLE_VOX
     && !gEeprom.VOX_SWITCH
 #endif
+#ifdef ENABLE_FEAT_F4HWN
+    && !gSetting_set_ptt_session
+#endif
     )
     return;
 


### PR DESCRIPTION
**Hello.**

A tiny fix related to the previous pull request: I didn’t account for OnePush when checking whether the PTT button had been released. For now, in OnePush mode, the volume will spike when the PTT button is pressed a second time - I’ll have to figure out later how to detect the second press.