### PR TITLE
Eliminating high bars in Audio Scope after releasing the DTMF button

### DIFF
--- a/App/ui/main.c
+++ b/App/ui/main.c
@@ -279,16 +279,17 @@ void UI_DisplayAudioScope(void)
         s_was_tx           = true;
     }
 
-    g_scope_buf[g_scope_write] = BK4819_GetVoiceAmplitudeOut();
-
-    // Let’s assume that values below 200 may be incorrect
-    // to avoid full-height bars that may appear on the first TX
-    if (g_scope_ready < SCOPE_SAMPLES) {
+    // The first 7 bars after turning on the radio
+    // will not display any values: they cause high bars.
+    if (g_scope_ready >= 7)
+        g_scope_buf[g_scope_write] = BK4819_GetVoiceAmplitudeOut();
+    else
         g_scope_ready++;
         
-        if (g_scope_buf[g_scope_write] < SCOPE_VOLUME_MIN) 
-            g_scope_buf[g_scope_write] = SCOPE_VOLUME_MIN;
-    }
+    // If the reading is 0, it is definitely an incorrect value
+    // caused by the microphone being muted - set it to 200.
+    if (g_scope_buf[g_scope_write] == 0) 
+        g_scope_buf[g_scope_write] =  SCOPE_VOLUME_MIN;
 
     g_scope_write = (g_scope_write + 1u) % SCOPE_SAMPLES;
 


### PR DESCRIPTION
**Hello.**

As I mentioned yesterday:

> I've noticed that high bars appear when a tone (DTMF/1750/ALARM) is entered during transmission. When the DTMF button is pressed, [...] after releasing the button, high bars appear, which disappear once the buffer is full.

I made this modification to the item. To give you a better idea of what it looked like, I recorded a before-and-after video:

Before:

https://github.com/user-attachments/assets/cd21dcd0-2c2c-4c0c-8e73-7a8aa32de31d

After:

https://github.com/user-attachments/assets/08827db1-4836-4714-bfe9-537dce43c0d5

