### PR TITLE
Fixed the issue where the squelch level would reset to 1 upon restart (#246)

### DIFF
--- a/App/app/app.c
+++ b/App/app/app.c
@@ -2144,7 +2144,6 @@ Skip:
         else
             flagSaveSettings = 1;
         gRequestSaveSettings = false;
-        gRequestSaveSquelch  = false;
         gUpdateStatus        = true;
     }
 

--- a/App/app/main.c
+++ b/App/app/main.c
@@ -301,6 +301,9 @@ static void processFKeyFunction(const KEY_Code_t Key, const bool beep)
                     RADIO_NextValidList(isKeyUp ? 1 : -1);
                 } else {
                     // Adjust squelch: UP increments, DOWN decrements
+                    if (gSquelchLevelOriginal == 10)
+                        gSquelchLevelOriginal =  gEeprom.SQUELCH_LEVEL;
+
                     if (isKeyUp) {
                         gEeprom.SQUELCH_LEVEL = (gEeprom.SQUELCH_LEVEL < 9) ? gEeprom.SQUELCH_LEVEL + 1 : 9;
                     } else {

--- a/App/app/menu.c
+++ b/App/app/menu.c
@@ -480,7 +480,9 @@ void MENU_AcceptSetting(void)
         case MENU_SQL:
             gEeprom.SQUELCH_LEVEL = gSubMenuSelection;
             gVfoConfigureMode     = VFO_CONFIGURE;
-            gRequestSaveSquelch   = true;
+            #ifdef ENABLE_FEAT_F4HWN
+                gSquelchLevelOriginal = 10;
+            #endif
             break;
 
         case MENU_STEP:

--- a/App/misc.c
+++ b/App/misc.c
@@ -250,7 +250,6 @@ bool              gFlagResetVfos;
 bool              gRequestSaveVFO;
 uint16_t          gRequestSaveChannel;
 bool              gRequestSaveSettings;
-bool              gRequestSaveSquelch;
 #ifdef ENABLE_FMRADIO
     bool          gRequestSaveFM;
 #endif
@@ -331,6 +330,7 @@ uint8_t           gIsLocked = 0xFF;
     bool          gMute = false;
     uint8_t       gBacklightTimeOriginal;
     uint8_t       gBacklightBrightnessOld;
+    uint8_t       gSquelchLevelOriginal = 10;
     uint8_t       gPttOnePushCounter = 0;
     uint32_t      gBlinkCounter = 0;
 

--- a/App/misc.h
+++ b/App/misc.h
@@ -375,7 +375,6 @@ extern bool                  gFlagResetVfos;
 extern bool                  gRequestSaveVFO;
 extern uint16_t              gRequestSaveChannel;
 extern bool                  gRequestSaveSettings;
-extern bool                  gRequestSaveSquelch;
 #ifdef ENABLE_FMRADIO
     extern bool              gRequestSaveFM;
 #endif
@@ -454,6 +453,7 @@ extern volatile uint8_t      boot_counter_10ms;
     extern bool                  gMute;
     extern uint8_t               gBacklightTimeOriginal;
     extern uint8_t               gBacklightBrightnessOld;
+    extern uint8_t               gSquelchLevelOriginal;
     extern uint8_t               gPttOnePushCounter;
     extern uint32_t              gBlinkCounter;
 

--- a/App/settings.c
+++ b/App/settings.c
@@ -766,10 +766,12 @@ void SETTINGS_SaveSettings(void)
     #ifdef ENABLE_FEAT_F4HWN_AUDIO
         State[0] = gSetting_set_audio;
     #endif
-    if (gRequestSaveSquelch)
-    {
+    #ifdef ENABLE_FEAT_F4HWN
+        if (gSquelchLevelOriginal < 10)
+            State[1] = gSquelchLevelOriginal;
+        else
+    #endif
         State[1] = gEeprom.SQUELCH_LEVEL;
-    }
     State[2] = gEeprom.TX_TIMEOUT_TIMER;
     #ifdef ENABLE_NOAA
         State[3] = gEeprom.NOAA_AUTO_SCAN;


### PR DESCRIPTION
**Hello.**

The problem turned out to be much more serious, and it stems from a mistake I made here: https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/ab7b4ca094632609b6c5dcb56cac94068c050d5b. I thought that when checking gRequestSaveSquelch, if it is false, the squelch value would not be saved to memory - on the contrary, it is saved with an incorrect value, hence the SQL1 error after the restart. My bad.

I changed the logic - I added gSquelchLevelOriginal to store the original squelch value when changing it with the F+Key_UP/F+Key_DOWN shortcut. It now works correctly, very similar to gBacklightTimeOriginal.