### PR TITLE
feat(bk4819): SetFrequency sub-Hz offset + Vernier LRU cache

### DIFF
--- a/App/CMakeLists.txt
+++ b/App/CMakeLists.txt
@@ -29,6 +29,7 @@ target_sources(App INTERFACE
     bitmaps.c
     board.c
     dcs.c
+    dsp/vernier.c
     font.c
     frequencies.c
     functions.c

--- a/App/app/main.c
+++ b/App/app/main.c
@@ -976,7 +976,7 @@ static void MAIN_Key_UP_DOWN(bool bKeyPressed, bool bKeyHeld, int8_t Direction)
                     return;
                 }
                 gTxVfo->freq_config_RX.Frequency = frequency;
-                BK4819_SetFrequency(frequency);
+                BK4819_SetFrequency(frequency, 0);
                 BK4819_RX_TurnOn();
                 gRequestSaveChannel = 1;
                 return;

--- a/App/app/spectrum.c
+++ b/App/app/spectrum.c
@@ -342,7 +342,7 @@ static void SetF(uint32_t f)
 {
     fMeasure = f;
 
-    BK4819_SetFrequency(fMeasure);
+    BK4819_SetFrequency(fMeasure, 0);
     BK4819_PickRXFilterPathBasedOnFrequency(fMeasure);
     uint16_t reg = BK4819_ReadRegister(BK4819_REG_30);
     BK4819_WriteRegister(BK4819_REG_30, 0);

--- a/App/driver/bk4819.c
+++ b/App/driver/bk4819.c
@@ -28,6 +28,7 @@
 #include "driver/system.h"
 #include "driver/systick.h"
 
+#include "dsp/vernier.h"
 
 #define PIN_CSN GPIO_MAKE_PIN(GPIOF, LL_GPIO_PIN_9)
 #define PIN_SCL GPIO_MAKE_PIN(GPIOB, LL_GPIO_PIN_8)
@@ -720,10 +721,96 @@ void BK4819_SetupPowerAmplifier(const uint8_t bias, const uint32_t frequency)
     BK4819_WriteRegister(BK4819_REG_36, (bias << 8) | (enable << 7) | (gain << 0));
 }
 
-void BK4819_SetFrequency(uint32_t Frequency)
+#define VERNIER_LUT_SIZE 20U
+
+typedef struct {
+    uint32_t freq;
+    int8_t   delta_dhz;
+    uint8_t  age;
+    uint32_t pll_freq;
+    uint16_t reg3b;
+} VernierLutEntry_t;
+
+static VernierLutEntry_t sVernierLut[VERNIER_LUT_SIZE];
+static uint8_t           sLutCount;
+
+static void WritePllAndTrim(uint32_t pll_freq, uint16_t reg3b)
 {
-    BK4819_WriteRegister(BK4819_REG_38, (Frequency >>  0) & 0xFFFF);
-    BK4819_WriteRegister(BK4819_REG_39, (Frequency >> 16) & 0xFFFF);
+    BK4819_WriteRegister(BK4819_REG_38, (pll_freq >>  0) & 0xFFFF);
+    BK4819_WriteRegister(BK4819_REG_39, (pll_freq >> 16) & 0xFFFF);
+    BK4819_WriteRegister(BK4819_REG_3B, reg3b);
+
+    uint16_t reg30 = BK4819_ReadRegister(BK4819_REG_30);
+    BK4819_WriteRegister(BK4819_REG_30, 0);
+    BK4819_WriteRegister(BK4819_REG_30, reg30);
+}
+
+void BK4819_SetFrequency(uint32_t Frequency, int8_t delta_dhz)
+{
+    if (delta_dhz == 0) {
+        BK4819_WriteRegister(BK4819_REG_38, (Frequency >>  0) & 0xFFFF);
+        BK4819_WriteRegister(BK4819_REG_39, (Frequency >> 16) & 0xFFFF);
+        BK4819_WriteRegister(BK4819_REG_3B, (uint16_t)(22656 + gEeprom.BK4819_XTAL_FREQ_LOW));
+        return;
+    }
+
+    for (uint8_t i = 0; i < sLutCount; i++) {
+        if (sVernierLut[i].freq == Frequency && sVernierLut[i].delta_dhz == delta_dhz) {
+            for (uint8_t j = 0; j < sLutCount; j++)
+                sVernierLut[j].age++;
+            sVernierLut[i].age = 0;
+            WritePllAndTrim(sVernierLut[i].pll_freq, sVernierLut[i].reg3b);
+            return;
+        }
+    }
+
+    int32_t fine_mhz = (int32_t)delta_dhz * 100;
+    int     negative = fine_mhz < 0;
+    if (negative)
+        fine_mhz = -fine_mhz;
+
+    uint32_t alpha = VERNIER_ComputeAlpha(Frequency * 10U);
+    VernierResult_t v = VERNIER_Solve(fine_mhz, alpha);
+
+    const uint16_t base3b = (uint16_t)(22656 + gEeprom.BK4819_XTAL_FREQ_LOW);
+    uint32_t       pll_freq;
+    uint16_t       reg3b;
+
+    if (!negative) {
+        pll_freq = (Frequency > v.pll_comp) ? (Frequency - v.pll_comp) : 0U;
+        reg3b    = (uint16_t)(((uint32_t)base3b >= (uint32_t)v.xtal_trim)
+                                  ? ((uint32_t)base3b - (uint32_t)v.xtal_trim)
+                                  : 0U);
+    } else {
+        pll_freq = Frequency + (uint32_t)v.pll_comp;
+        reg3b    = (uint16_t)((uint32_t)base3b + (uint32_t)v.xtal_trim);
+    }
+
+    uint8_t slot;
+    if (sLutCount < VERNIER_LUT_SIZE) {
+        for (uint8_t j = 0; j < sLutCount; j++)
+            sVernierLut[j].age++;
+        slot = sLutCount;
+        sLutCount++;
+    } else {
+        slot = 0;
+        for (uint8_t i = 1; i < VERNIER_LUT_SIZE; i++) {
+            if (sVernierLut[i].age > sVernierLut[slot].age)
+                slot = i;
+        }
+        for (uint8_t j = 0; j < VERNIER_LUT_SIZE; j++) {
+            if (j != slot)
+                sVernierLut[j].age++;
+        }
+    }
+
+    sVernierLut[slot].freq = Frequency;
+    sVernierLut[slot].delta_dhz = delta_dhz;
+    sVernierLut[slot].pll_freq = pll_freq;
+    sVernierLut[slot].reg3b = reg3b;
+    sVernierLut[slot].age = 0;
+
+    WritePllAndTrim(pll_freq, reg3b);
 }
 
 void BK4819_SetupSquelch(
@@ -1588,7 +1675,7 @@ void BK4819_EnableFrequencyScan(void)
 
 void BK4819_SetScanFrequency(uint32_t Frequency)
 {
-    BK4819_SetFrequency(Frequency);
+    BK4819_SetFrequency(Frequency, 0);
 
     // REG_51
     //

--- a/App/driver/bk4819.h
+++ b/App/driver/bk4819.h
@@ -84,7 +84,7 @@ void     BK4819_SetTailDetection(const uint32_t freq_10Hz);
 void     BK4819_EnableVox(uint16_t Vox1Threshold, uint16_t Vox0Threshold);
 void     BK4819_SetFilterBandwidth(const BK4819_FilterBandwidth_t Bandwidth, const bool weak_no_different);
 void     BK4819_SetupPowerAmplifier(const uint8_t bias, const uint32_t frequency);
-void     BK4819_SetFrequency(uint32_t Frequency);
+void     BK4819_SetFrequency(uint32_t Frequency, int8_t delta_dhz);
 void     BK4819_SetupSquelch(
             uint8_t SquelchOpenRSSIThresh,
             uint8_t SquelchCloseRSSIThresh,

--- a/App/driver/bk4829.c
+++ b/App/driver/bk4829.c
@@ -28,6 +28,8 @@
 #include "driver/system.h"
 #include "driver/systick.h"
 
+#include "dsp/vernier.h"
+
 #define PIN_CSN GPIO_MAKE_PIN(GPIOF, LL_GPIO_PIN_9)
 #define PIN_SCL GPIO_MAKE_PIN(GPIOB, LL_GPIO_PIN_8)
 #define PIN_SDA GPIO_MAKE_PIN(GPIOB, LL_GPIO_PIN_9)
@@ -721,10 +723,96 @@ void BK4819_SetupPowerAmplifier(const uint8_t bias, const uint32_t frequency)
     BK4819_WriteRegister(BK4819_REG_36, (bias << 8) | (enable << 7) | (gain << 0));
 }
 
-void BK4819_SetFrequency(uint32_t Frequency)
+#define VERNIER_LUT_SIZE 20U
+
+typedef struct {
+    uint32_t freq;
+    int8_t   delta_dhz;
+    uint8_t  age;
+    uint32_t pll_freq;
+    uint16_t reg3b;
+} VernierLutEntry_t;
+
+static VernierLutEntry_t sVernierLut[VERNIER_LUT_SIZE];
+static uint8_t           sLutCount;
+
+static void WritePllAndTrim(uint32_t pll_freq, uint16_t reg3b)
 {
-    BK4819_WriteRegister(BK4819_REG_38, (Frequency >>  0) & 0xFFFF);
-    BK4819_WriteRegister(BK4819_REG_39, (Frequency >> 16) & 0xFFFF);
+    BK4819_WriteRegister(BK4819_REG_38, (pll_freq >>  0) & 0xFFFF);
+    BK4819_WriteRegister(BK4819_REG_39, (pll_freq >> 16) & 0xFFFF);
+    BK4819_WriteRegister(BK4819_REG_3B, reg3b);
+
+    uint16_t reg30 = BK4819_ReadRegister(BK4819_REG_30);
+    BK4819_WriteRegister(BK4819_REG_30, 0);
+    BK4819_WriteRegister(BK4819_REG_30, reg30);
+}
+
+void BK4819_SetFrequency(uint32_t Frequency, int8_t delta_dhz)
+{
+    if (delta_dhz == 0) {
+        BK4819_WriteRegister(BK4819_REG_38, (Frequency >>  0) & 0xFFFF);
+        BK4819_WriteRegister(BK4819_REG_39, (Frequency >> 16) & 0xFFFF);
+        BK4819_WriteRegister(BK4819_REG_3B, (uint16_t)(22656 + gEeprom.BK4819_XTAL_FREQ_LOW));
+        return;
+    }
+
+    for (uint8_t i = 0; i < sLutCount; i++) {
+        if (sVernierLut[i].freq == Frequency && sVernierLut[i].delta_dhz == delta_dhz) {
+            for (uint8_t j = 0; j < sLutCount; j++)
+                sVernierLut[j].age++;
+            sVernierLut[i].age = 0;
+            WritePllAndTrim(sVernierLut[i].pll_freq, sVernierLut[i].reg3b);
+            return;
+        }
+    }
+
+    int32_t fine_mhz = (int32_t)delta_dhz * 100;
+    int     negative = fine_mhz < 0;
+    if (negative)
+        fine_mhz = -fine_mhz;
+
+    uint32_t alpha = VERNIER_ComputeAlpha(Frequency * 10U);
+    VernierResult_t v = VERNIER_Solve(fine_mhz, alpha);
+
+    const uint16_t base3b = (uint16_t)(22656 + gEeprom.BK4819_XTAL_FREQ_LOW);
+    uint32_t       pll_freq;
+    uint16_t       reg3b;
+
+    if (!negative) {
+        pll_freq = (Frequency > v.pll_comp) ? (Frequency - v.pll_comp) : 0U;
+        reg3b    = (uint16_t)(((uint32_t)base3b >= (uint32_t)v.xtal_trim)
+                                  ? ((uint32_t)base3b - (uint32_t)v.xtal_trim)
+                                  : 0U);
+    } else {
+        pll_freq = Frequency + (uint32_t)v.pll_comp;
+        reg3b    = (uint16_t)((uint32_t)base3b + (uint32_t)v.xtal_trim);
+    }
+
+    uint8_t slot;
+    if (sLutCount < VERNIER_LUT_SIZE) {
+        for (uint8_t j = 0; j < sLutCount; j++)
+            sVernierLut[j].age++;
+        slot = sLutCount;
+        sLutCount++;
+    } else {
+        slot = 0;
+        for (uint8_t i = 1; i < VERNIER_LUT_SIZE; i++) {
+            if (sVernierLut[i].age > sVernierLut[slot].age)
+                slot = i;
+        }
+        for (uint8_t j = 0; j < VERNIER_LUT_SIZE; j++) {
+            if (j != slot)
+                sVernierLut[j].age++;
+        }
+    }
+
+    sVernierLut[slot].freq = Frequency;
+    sVernierLut[slot].delta_dhz = delta_dhz;
+    sVernierLut[slot].pll_freq = pll_freq;
+    sVernierLut[slot].reg3b = reg3b;
+    sVernierLut[slot].age = 0;
+
+    WritePllAndTrim(pll_freq, reg3b);
 }
 
 void BK4819_SetupSquelch(
@@ -1612,7 +1700,7 @@ void BK4819_EnableFrequencyScan(void)
 
 void BK4819_SetScanFrequency(uint32_t Frequency)
 {
-    BK4819_SetFrequency(Frequency);
+    BK4819_SetFrequency(Frequency, 0);
 
     // REG_51
     //

--- a/App/dsp/vernier.c
+++ b/App/dsp/vernier.c
@@ -1,0 +1,62 @@
+/* Copyright 2025 bg7nzl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dsp/vernier.h"
+
+#define MAX_XTAL_TRIM  600
+#define PLL_STEP_MHZ   10000   // 10 Hz expressed in mHz
+
+VernierResult_t VERNIER_Solve(int32_t delta_f_mhz, uint32_t alpha_mhz)
+{
+    VernierResult_t best;
+    best.xtal_trim = 0;
+    best.pll_comp  = 0;
+    best.error_mhz = 32767;
+
+    if (alpha_mhz == 0)
+        return best;
+
+    for (uint16_t xt = 0; xt <= MAX_XTAL_TRIM; xt++)
+    {
+        int32_t xtal_effect = (int32_t)xt * (int32_t)alpha_mhz;
+
+        int32_t pc = (xtal_effect - delta_f_mhz + (PLL_STEP_MHZ / 2)) / PLL_STEP_MHZ;
+        if (pc < 0)
+            continue;
+
+        int32_t actual = xtal_effect - pc * PLL_STEP_MHZ;
+        int32_t err = actual - delta_f_mhz;
+        if (err < 0)
+            err = -err;
+
+        if (err < best.error_mhz)
+        {
+            best.xtal_trim = xt;
+            best.pll_comp  = (uint16_t)pc;
+            best.error_mhz = (int16_t)err;
+            if (err == 0)
+                break;
+        }
+    }
+
+    return best;
+}
+
+uint32_t VERNIER_ComputeAlpha(uint32_t f_carrier_hz)
+{
+    // alpha = 5000 * f / 26000000 (mHz per LSB of REG_3B)
+    // Use 64-bit intermediate to avoid overflow
+    return (uint32_t)((5000ULL * (uint64_t)f_carrier_hz) / 26000000ULL);
+}

--- a/App/dsp/vernier.h
+++ b/App/dsp/vernier.h
@@ -1,0 +1,47 @@
+/* Copyright 2025 bg7nzl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DSP_VERNIER_H
+#define DSP_VERNIER_H
+
+#include <stdint.h>
+
+typedef struct {
+    uint16_t xtal_trim;  // REG_3B offset (crystal oscillator trim)
+    uint16_t pll_comp;   // REG_38/39 offset (PLL compensation steps)
+    int16_t  error_mhz;  // residual error in mHz
+} VernierResult_t;
+
+/*
+ * Solve for the best (xtal_trim, pll_comp) pair that produces the desired
+ * sub-10-Hz frequency offset using the Vernier technique.
+ *
+ * delta_f_mhz : desired offset in millihertz (0 .. 9999)
+ * alpha_mhz   : xtal trim sensitivity in mHz/LSB,
+ *               pre-computed as (5000 * f_carrier_hz) / 26000000
+ *
+ * The Vernier effect:
+ *   actual offset = xtal_trim * alpha_mhz - pll_comp * 10000  (mHz)
+ * We search xtal_trim in [0..600] and pick the best integer pll_comp.
+ */
+VernierResult_t VERNIER_Solve(int32_t delta_f_mhz, uint32_t alpha_mhz);
+
+/*
+ * Pre-compute alpha_mhz for a given carrier frequency.
+ * alpha_mhz = 5000 * f_carrier_hz / 26000000
+ */
+uint32_t VERNIER_ComputeAlpha(uint32_t f_carrier_hz);
+
+#endif

--- a/App/radio.c
+++ b/App/radio.c
@@ -839,7 +839,7 @@ void RADIO_SetupRegisters(bool switchToForeground)
     #else
         Frequency = gRxVfo->pRX->Frequency;
     #endif
-    BK4819_SetFrequency(Frequency);
+    BK4819_SetFrequency(Frequency, 0);
 
     BK4819_SetupSquelch(
         gRxVfo->SquelchOpenRSSIThresh,    gRxVfo->SquelchCloseRSSIThresh,
@@ -1048,7 +1048,7 @@ void RADIO_SetTxParameters(void)
             break;
     }
 
-    BK4819_SetFrequency(gCurrentVfo->pTX->Frequency);
+    BK4819_SetFrequency(gCurrentVfo->pTX->Frequency, 0);
 
     // TX compressor
     BK4819_SetCompander((gRxVfo->Modulation == MODULATION_FM && (gRxVfo->Compander == 1 || gRxVfo->Compander >= 3)) ? gRxVfo->Compander : 0);


### PR DESCRIPTION
Add dsp/vernier.c Vernier solver from cw-digimode
BK4819_SetFrequency(freq, delta_dhz): 
  - delta 0 = EEPROM REG_3B baseline 
  - Non-zero: Vernier + 20-entry LRU cache of (pll_freq, reg3b)

REG_30 toggle after trim writes