### PR TITLE
Code optimization (80 B), behavior of the EXIT button when editing ChName

### DIFF
--- a/App/app/menu.c
+++ b/App/app/menu.c
@@ -1655,20 +1655,16 @@ static void MENU_Key_EXIT(bool bKeyPressed, bool bKeyHeld)
             if (bKeyHeld)
                 return; // release after a long press, keep editing
 
-            /* Backlight related menus set full brightness. Set it back to the configured value,
-               just in case we are exiting from one of them. */
-            BACKLIGHT_TurnOn();
+            if (edit_index == 0)
+                goto Skip;
 
-            gAskForConfirmation = 0;
-            gIsInSubMenu        = false;
-            gInputBoxIndex      = 0;
-            gFlagRefreshSetting = true;
+            if (edit_index > 0)
+            {   // step back one character while editing the channel name
+                edit_index--;
+                gAskForConfirmation = 0;
+                gRequestDisplayScreen = DISPLAY_MENU;
+            }
 
-            #ifdef ENABLE_VOICE
-                gAnotherVoiceID = VOICE_ID_CANCEL;
-            #endif
-
-            gRequestDisplayScreen = DISPLAY_MENU;
             return;
         }
 
@@ -1678,16 +1674,22 @@ static void MENU_Key_EXIT(bool bKeyPressed, bool bKeyHeld)
             return;
         }
 
+Skip:
+
         /* Backlight related menus set full brightness. Set it back to the configured value,
            just in case we are editing from one of them. */
         BACKLIGHT_TurnOn();
 
-        if (edit_index > 0)
-        {   // step back one character while editing the channel name
-            edit_index--;
-            gAskForConfirmation = 0;
-            gRequestDisplayScreen = DISPLAY_MENU;
-        }
+        gAskForConfirmation = 0;
+        gIsInSubMenu        = false;
+        gInputBoxIndex      = 0;
+        gFlagRefreshSetting = true;
+
+        #ifdef ENABLE_VOICE
+            gAnotherVoiceID = VOICE_ID_CANCEL;
+        #endif
+
+        gRequestDisplayScreen = DISPLAY_MENU;
 
         return;
     }
@@ -1699,29 +1701,22 @@ static void MENU_Key_EXIT(bool bKeyPressed, bool bKeyHeld)
 
     if (!gCssBackgroundScan)
     {
-        /* Backlight related menus set full brightness. Set it back to the configured value,
-           just in case we are exiting from one of them. */
-        BACKLIGHT_TurnOn();
-
         if (gIsInSubMenu)
         {
             if (gInputBoxIndex == 0 || UI_MENU_GetCurrentMenuId() != MENU_OFFSET)
             {
-                gAskForConfirmation = 0;
-                gIsInSubMenu        = false;
-                gInputBoxIndex      = 0;
-                gFlagRefreshSetting = true;
-
-                #ifdef ENABLE_VOICE
-                    gAnotherVoiceID = VOICE_ID_CANCEL;
-                #endif
+                goto Skip;
             }
             else
+            {
+                /* Backlight related menus set full brightness. Set it back to the configured value,
+                   just in case we are exiting from one of them. */
+                BACKLIGHT_TurnOn();
+
                 gInputBox[--gInputBoxIndex] = 10;
+                gRequestDisplayScreen = DISPLAY_MENU;
+            }
 
-            // ***********************
-
-            gRequestDisplayScreen = DISPLAY_MENU;
             return;
         }
 

--- a/App/app/spectrum.c
+++ b/App/app/spectrum.c
@@ -130,6 +130,18 @@ const int8_t LNAsOptions[] = {-19, -16, -11, 0};
 const int8_t LNAOptions[] = {-24, -19, -14, -9, -6, -4, -2, 0};
 const int8_t VGAOptions[] = {-33, -27, -21, -15, -9, -6, -3, 0};
 //const char *BPFOptions[] = {"8.46", "7.25", "6.35", "5.64", "5.08", "4.62", "4.23"};
+
+typedef struct {
+    const int8_t *options;
+    uint8_t count;
+} MenuOptions;
+
+static const MenuOptions regOptions[] = {
+    {NULL, 0},             // NULL
+    {LNAsOptions, 4},      // LNAs
+    {LNAOptions, 8},       // LNA
+    {VGAOptions, 8}        // VGA
+};
 #endif
 
 uint16_t statuslineUpdateTimer = 0;
@@ -1288,9 +1300,13 @@ static void ShowChannelName(uint32_t f)
 }
 #endif
 
+static void FormatFrequency(uint32_t freq, char *buffer) {
+    sprintf(buffer, "%u.%05u", freq / 100000, freq % 100000);
+}
+
 static void DrawF(uint32_t f)
 {
-    sprintf(String, "%u.%05u", f / 100000, f % 100000);
+    FormatFrequency(f, String);
     UI_PrintStringSmallNormal(String, 8, 127, 0);
 
     sprintf(String, "%3s", gModulationStr[settings.modulationType]);
@@ -1333,14 +1349,14 @@ static void DrawNums()
     }
     else
     {
-        sprintf(String, "%u.%05u", GetFStart() / 100000, GetFStart() % 100000);
+        FormatFrequency(GetFStart(), String);
         GUI_DisplaySmallest(String, 0, 49, false, true);
 
         sprintf(String, "\x7F%u.%02uk", settings.frequencyChangeStep / 100,
                 settings.frequencyChangeStep % 100);
         GUI_DisplaySmallest(String, 48, 49, false, true);
 
-        sprintf(String, "%u.%05u", GetFEnd() / 100000, GetFEnd() % 100000);
+        FormatFrequency(GetFEnd(), String);
         GUI_DisplaySmallest(String, 93, 49, false, true);
     }
 }
@@ -1683,6 +1699,9 @@ static void RenderStill()
                             menuState != idx);
 
 #ifdef ENABLE_FEAT_F4HWN_SPECTRUM
+        sprintf(String, "%ddB", regOptions[idx].options[GetRegMenuValue(idx)]);
+
+        /*
         if(idx == 1)
         {
             sprintf(String, "%ddB", LNAsOptions[GetRegMenuValue(idx)]);
@@ -1695,7 +1714,6 @@ static void RenderStill()
         {
             sprintf(String, "%ddB", VGAOptions[GetRegMenuValue(idx)]);
         }
-        /*
         else if(idx == 4)
         {
             sprintf(String, "%skHz", BPFOptions[(GetRegMenuValue(idx) / 0x2aaa)]);


### PR DESCRIPTION
Hello.

The new Spectrum interface looks great. Looking at the code, I noticed that there are a few places where we could save a few dozen bytes. I managed to save 80 bytes.

I changed (or rather, swapped) the behavior of the EXIT button while editing ChName. Originally, a short press exited editing mode, while a longer press moved the cursor back one character. In my opinion, this is quite confusing, since in other places, such as when entering frequencies, a short press deleted one digit, while a longer press canceled the entry.

I hope you like this change and I look forward to your feedback.

---

As for ChName - I had the idea to allow entering characters the way you used to type SMS messages on old Nokia phones. I’m encouraged by the fact that on the UV-K1, the 1-9 keys have letters printed on them:

<img width="402" height="321" alt="image" src="https://github.com/user-attachments/assets/06d7ed74-af88-4f88-b80f-aa0422716b6f" />



I’m curious to hear your opinion and whether I should try to implement this feature. Of course, I was thinking of keeping the option to select characters using the old KEY_DOWN/KEY_UP method alongside this new feature.