### PR TITLE
Code refactoring (180 B)

### DIFF
--- a/App/app/action.c
+++ b/App/app/action.c
@@ -660,26 +660,25 @@ void ACTION_Mute(void)
         BK1080_WriteRegister(BK1080_REG_05_SYSTEM_CONFIGURATION2, gMute ? 0x0A10 : 0x0A1F);
     #endif
     gEeprom.VOLUME_GAIN = gMute ? 0 : gEeprom.VOLUME_GAIN_BACKUP;
-    BK4819_WriteRegister(BK4819_REG_48,
-        (11u << 12)                |  // ??? .. 0 ~ 15, doesn't seem to make any difference
-        (0u << 10)                 |  // AF Rx Gain-1
-        (gEeprom.VOLUME_GAIN << 4) |  // AF Rx Gain-2
-        (gEeprom.DAC_GAIN << 0));     // AF DAC Gain (after Gain-1 and Gain-2)
+    BK4819_SetRxAudioGain();
 
     gUpdateStatus = true;
 }
 
 #ifdef ENABLE_FEAT_F4HWN_RESCUE_OPS
+void ACTION_ToggleVfoSetting(bool *setting) {
+    *setting = !(*setting);
+    gVfoConfigureMode = VFO_CONFIGURE_RELOAD;
+}
+
 void ACTION_Power_High(void)
 {
-    gPowerHigh = !gPowerHigh;
-    gVfoConfigureMode = VFO_CONFIGURE_RELOAD;
+    ACTION_ToggleVfoSetting(&gPowerHigh);
 }
 
 void ACTION_Remove_Offset(void)
 {
-    gRemoveOffset = !gRemoveOffset;
-    gVfoConfigureMode = VFO_CONFIGURE_RELOAD;
+    ACTION_ToggleVfoSetting(&gRemoveOffset);
 }
 #endif
 #endif

--- a/App/app/app.c
+++ b/App/app/app.c
@@ -557,11 +557,7 @@ void APP_StartListening(FUNCTION_Type_t function)
         gUpdateStatus    = true;
     }
 
-    BK4819_WriteRegister(BK4819_REG_48,
-        (11u << 12)                |     // ??? .. 0 to 15, doesn't seem to make any difference
-        ( 0u << 10)                |     // AF Rx Gain-1
-        (gEeprom.VOLUME_GAIN << 4) |     // AF Rx Gain-2
-        (gEeprom.DAC_GAIN    << 0));     // AF DAC Gain (after Gain-1 and Gain-2)
+    BK4819_SetRxAudioGain();
 
 #ifdef ENABLE_VOICE
     if (gVoiceWriteIndex == 0)       // AM/FM RX mode will be set when the voice has finished

--- a/App/app/app.c
+++ b/App/app/app.c
@@ -812,6 +812,22 @@ void APP_EndTransmission(void)
     }
 }
 
+void APP_HandleEndTransmission(void) {
+    if (gFlagEndTransmission) {
+        FUNCTION_Select(FUNCTION_FOREGROUND);
+    }
+    else {
+        APP_EndTransmission();
+
+        if (gEeprom.REPEATER_TAIL_TONE_ELIMINATION == 0)
+            FUNCTION_Select(FUNCTION_FOREGROUND);
+        else
+            gRTTECountdown_10ms = gEeprom.REPEATER_TAIL_TONE_ELIMINATION * 10;
+    }
+
+    gFlagEndTransmission = false;
+}
+
 #ifdef ENABLE_VOX
 static void HandleVox(void)
 {
@@ -847,24 +863,10 @@ static void HandleVox(void)
             gVOX_NoiseDetected = false;
 
         if (gCurrentFunction == FUNCTION_TRANSMIT && !gPttIsPressed && !gVOX_NoiseDetected) {
-            if (gFlagEndTransmission) {
-                //if (gCurrentFunction != FUNCTION_FOREGROUND)
-                    FUNCTION_Select(FUNCTION_FOREGROUND);
-            }
-            else {
-                APP_EndTransmission();
-
-                if (gEeprom.REPEATER_TAIL_TONE_ELIMINATION == 0) {
-                    //if (gCurrentFunction != FUNCTION_FOREGROUND)
-                        FUNCTION_Select(FUNCTION_FOREGROUND);
-                }
-                else
-                    gRTTECountdown_10ms = gEeprom.REPEATER_TAIL_TONE_ELIMINATION * 10;
-            }
+            APP_HandleEndTransmission();
 
             gUpdateStatus        = true;
             gUpdateDisplay       = true;
-            gFlagEndTransmission = false;
         }
         return;
     }
@@ -1942,12 +1944,10 @@ static void ProcessKey(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
     bool lowBatPopup = gLowBattery && !gLowBatteryConfirmed &&  gScreenToDisplay == DISPLAY_MAIN;
 
 #ifdef ENABLE_FEAT_F4HWN // Disable PTT if KEY_LOCK
-    bool lck_condition = false;
+    bool lck_condition = (gEeprom.KEY_LOCK || lowBatPopup) && gCurrentFunction != FUNCTION_TRANSMIT;
 
-    if(gSetting_set_lck)
-        lck_condition = (gEeprom.KEY_LOCK || lowBatPopup) && gCurrentFunction != FUNCTION_TRANSMIT;
-    else
-        lck_condition = (gEeprom.KEY_LOCK || lowBatPopup) && gCurrentFunction != FUNCTION_TRANSMIT && Key != KEY_PTT;
+    if(!gSetting_set_lck)
+        lck_condition = lck_condition && Key != KEY_PTT;
 
     if (lck_condition)
 #else

--- a/App/app/app.h
+++ b/App/app/app.h
@@ -24,6 +24,7 @@
 #include "radio.h"
 
 void     APP_EndTransmission(void);
+void     APP_HandleEndTransmission(void);
 void     APP_StartListening(FUNCTION_Type_t function);
 uint32_t APP_SetFreqByStepAndLimits(VFO_Info_t *pInfo, int8_t direction, uint32_t lower, uint32_t upper);
 uint32_t APP_SetFrequencyByStep(VFO_Info_t *pInfo, int8_t direction);

--- a/App/app/generic.c
+++ b/App/app/generic.c
@@ -103,20 +103,8 @@ void GENERIC_Key_PTT(bool bKeyPressed)
     if (!bKeyPressed || SerialConfigInProgress())
     {   // PTT released
         if (gCurrentFunction == FUNCTION_TRANSMIT) {    
-            // we are transmitting .. stop
-            if (gFlagEndTransmission) {
-                FUNCTION_Select(FUNCTION_FOREGROUND);
-            }
-            else {
-                APP_EndTransmission();
+            APP_HandleEndTransmission();
 
-                if (gEeprom.REPEATER_TAIL_TONE_ELIMINATION == 0)
-                    FUNCTION_Select(FUNCTION_FOREGROUND);
-                else
-                    gRTTECountdown_10ms = gEeprom.REPEATER_TAIL_TONE_ELIMINATION * 10;
-            }
-
-            gFlagEndTransmission = false;
 #ifdef ENABLE_VOX
             gVOX_NoiseDetected = false;
 #endif

--- a/App/app/scanner.c
+++ b/App/app/scanner.c
@@ -345,7 +345,7 @@ void SCANNER_Start(bool singleFreq)
         gScanFrequency = 0xFFFFFFFF;
 
         BK4819_PickRXFilterPathBasedOnFrequency(gScanFrequency);
-        BK4819_EnableFrequencyScan();
+        BK4819_SetFrequencyScan(true);
 
         gUpdateStatus = true;
     }
@@ -418,10 +418,10 @@ void SCANNER_TimeSlice10ms(void)
             else
                 scanHitCount = 0;
 
-            BK4819_DisableFrequencyScan();
+            BK4819_SetFrequencyScan(false);
 
             if (scanHitCount < 3) {
-                BK4819_EnableFrequencyScan();
+                BK4819_SetFrequencyScan(true);
             }
             else {
                 BK4819_SetScanFrequency(gScanFrequency);

--- a/App/driver/bk4819.h
+++ b/App/driver/bk4819.h
@@ -147,11 +147,11 @@ uint8_t  BK4819_GetGlitchIndicator(void);
 uint8_t  BK4819_GetExNoiceIndicator(void);
 uint16_t BK4819_GetVoiceAmplitudeOut(void);
 uint8_t  BK4819_GetAfTxRx(void);
+void     BK4819_SetRxAudioGain(void);
 
 bool     BK4819_GetFrequencyScanResult(uint32_t *pFrequency);
 BK4819_CssScanResult_t BK4819_GetCxCSSScanResult(uint32_t *pCdcssFreq, uint16_t *pCtcssFreq);
-void     BK4819_DisableFrequencyScan(void);
-void     BK4819_EnableFrequencyScan(void);
+void     BK4819_SetFrequencyScan(bool enable);
 void     BK4819_SetScanFrequency(uint32_t Frequency);
 
 void     BK4819_Disable(void);

--- a/App/driver/bk4829.c
+++ b/App/driver/bk4829.c
@@ -1432,24 +1432,15 @@ void BK4819_GenTail(uint8_t Tail)
     //                          freq(Hz) * 20.64888 for XTAL 13M/26M or
     //                          freq(Hz)*20.97152 for XTAL 12.8M/19.2M/25.6M/38.4M
 
-    switch (Tail)
-    {
-        case 0: // 134.4Hz CTCSS Tail
-            BK4819_WriteRegister(BK4819_REG_52, 0x828F);   // 1 00 0 001010 001111
-            break;
-        case 1: // 120° phase shift
-            BK4819_WriteRegister(BK4819_REG_52, 0xA28F);   // 1 01 0 001010 001111
-            break;
-        case 2: // 180° phase shift
-            BK4819_WriteRegister(BK4819_REG_52, 0xC28F);   // 1 10 0 001010 001111
-            break;
-        case 3: // 240° phase shift
-            BK4819_WriteRegister(BK4819_REG_52, 0xE28F);   // 1 11 0 001010 001111
-            break;
-        case 4: // 55Hz tone freq
-            BK4819_WriteRegister(BK4819_REG_07, 0x046f);   // 0 00 0 010001 101111
-            break;
-    }
+    if (Tail <= 3)
+        // 0: 134.4Hz CTCSS Tail
+        // 1: 120° phase shift
+        // 2: 180° phase shift
+        // 3: 240° phase shift
+        BK4819_WriteRegister(BK4819_REG_52, 0x028F | (Tail << 13));
+    else if (Tail == 4)
+        // 4: 55Hz tone freq
+        BK4819_WriteRegister(BK4819_REG_07, 0x046F);
 }
 
 void BK4819_PlayCDCSSTail(void)
@@ -1531,6 +1522,14 @@ uint8_t BK4819_GetAfTxRx(void)
     return BK4819_ReadRegister(BK4819_REG_6F) & 0x003F;
 }
 
+void BK4819_SetRxAudioGain(void) {
+    BK4819_WriteRegister(BK4819_REG_48,
+        (11u << 12)                |     // ??? .. 0 ~ 15, doesn't seem to make any difference
+        ( 0u << 10)                |     // AF Rx Gain-1
+        (gEeprom.VOLUME_GAIN << 4) |     // AF Rx Gain-2
+        (gEeprom.DAC_GAIN    << 0));     // AF DAC Gain (after Gain-1 and Gain-2)
+}
+
 bool BK4819_GetFrequencyScanResult(uint32_t *pFrequency)
 {
     const uint16_t High     = BK4819_ReadRegister(BK4819_REG_0D);
@@ -1566,7 +1565,7 @@ BK4819_CssScanResult_t BK4819_GetCxCSSScanResult(uint32_t *pCdcssFreq, uint16_t 
     return BK4819_CSS_RESULT_NOT_FOUND;
 }
 
-void BK4819_DisableFrequencyScan(void)
+void BK4819_SetFrequencyScan(bool enable)
 {
     // REG_32
     //
@@ -1582,32 +1581,10 @@ void BK4819_DisableFrequencyScan(void)
     //         1 = enable
     //         0 = disable
     //
-    BK4819_WriteRegister(BK4819_REG_32, // 0x0244);    // 00 0000100100010 0
+    BK4819_WriteRegister(BK4819_REG_32,
         (  0u << 14) |          // 0 frequency scan Time
         (290u <<  1) |          // ???
-        (  0u <<  0));          // 0 frequency scan enable
-}
-
-void BK4819_EnableFrequencyScan(void)
-{
-    // REG_32
-    //
-    // <15:14> 0 frequency scan time
-    //         0 = 0.2 sec
-    //         1 = 0.4 sec
-    //         2 = 0.8 sec
-    //         3 = 1.6 sec
-    //
-    // <13:1>  ???
-    //
-    // <0>     0 frequency scan enable
-    //         1 = enable
-    //         0 = disable
-    //
-    BK4819_WriteRegister(BK4819_REG_32, // 0x0245);   // 00 0000100100010 1
-        (  0u << 14) |          // 0 frequency scan time
-        (290u <<  1) |          // ???
-        (  1u <<  0));          // 1 frequency scan enable
+        (enable ? 1u : 0u));    // frequency scan (1: enable | 0: disable)
 }
 
 void BK4819_SetScanFrequency(uint32_t Frequency)
@@ -1671,7 +1648,7 @@ void BK4819_Disable(void)
 
 void BK4819_StopScan(void)
 {
-    BK4819_DisableFrequencyScan();
+    BK4819_SetFrequencyScan(false);
     BK4819_Disable();
 }
 

--- a/App/radio.c
+++ b/App/radio.c
@@ -70,64 +70,45 @@ const char gModulationStr[MODULATION_UKNOWN][4] = {
     // Audio impression: fuller bass, more direct sound, while still keeping the 3 kHz top-end limit.
 
     static void AUDIO_ApplyFMProfile(uint8_t profile)
-    {
-        switch (profile)
-        {
-            default:
-            case 0: // FLAT
-                BK4819_WriteRegister(0x54, 0x9009);
-                BK4819_WriteRegister(0x55, 0x3200);
-                break;
+    {   //  | 0x54 || 0x55 |
+        static const uint16_t fm_profiles[][2] = {
+            {0x9009, 0x3200}, // 0: FLAT
+            {0x9009, 0x33A9}, // 1: CLEAN
+            {0x9009, 0x3600}, // 2: MID
+            {0x8546, 0x3AF0}, // 3: BOOST
+            {0x8566, 0x3D00}  // 4: MAX
+        };
 
-            case 1: // CLEAN
-                BK4819_WriteRegister(0x54, 0x9009);
-                BK4819_WriteRegister(0x55, 0x33A9);
-                break;
+        if (profile >= ARRAY_SIZE(fm_profiles))
+            profile = 0;
 
-            case 2: // MID
-                BK4819_WriteRegister(0x54, 0x9009);
-                BK4819_WriteRegister(0x55, 0x3600);
-                break;
-
-            case 3: // BOOST
-                BK4819_WriteRegister(0x54, 0x8546);
-                BK4819_WriteRegister(0x55, 0x3AF0);
-                break;
-
-            case 4: // MAX
-                BK4819_WriteRegister(0x54, 0x8566);
-                BK4819_WriteRegister(0x55, 0x3D00);
-                break;
-        }
+        BK4819_WriteRegister(0x54, fm_profiles[profile][0]);
+        BK4819_WriteRegister(0x55, fm_profiles[profile][1]);
     }
 
     static void AUDIO_ApplyAMProfile(uint8_t profile)
-    {
-        switch (profile)
-        {
-            default:
-            case 0: // SHARP (ALPHA test profile) - Narrow IF filter (REG54 bits[14:8]=0, bits[7:0]=9), low IF gain (REG55 bits[11:8]=1, ref=169)
-                    // Selective and crisp, best adjacent channel rejection, may sound harsh on strong signals
-                BK4819_WriteRegister(0x2b, 0x0300);
-                BK4819_WriteRegister(0x2f, 0x9990);
-                BK4819_WriteRegister(0x54, 0x9009);
-                BK4819_WriteRegister(0x55, 0x31A9);
-                break;
-            case 1: // STOCK - Narrow IF filter (REG54 bits[14:8]=0, bits[7:0]=9), moderate IF gain (REG55 bits[11:8]=4, ref=180)
-                    // Selective filter with balanced gain, punchy and detailed, good compromise between rejection and sensitivity
-                BK4819_WriteRegister(0x2b, 0x0500);
-                BK4819_WriteRegister(0x2f, 0x9990);
-                BK4819_WriteRegister(0x54, 0x9009);
-                BK4819_WriteRegister(0x55, 0x31A9);
-                break;
-            case 2: // OPEN (BRAVO test profile) - Medium-wide IF filter (REG54 bits[14:8]=8, bits[7:0]=70), high IF gain (REG55 bits[11:8]=8, ref=192)
-                    // Wide and pleasant, better sensitivity on weak signals, may struggle with adjacent channel interference
-                BK4819_WriteRegister(0x2b, 0x0300);
-                BK4819_WriteRegister(0x2f, 0x9990);
-                BK4819_WriteRegister(0x54, 0x8846);
-                BK4819_WriteRegister(0x55, 0x38C0);
-                break;
-        }
+    {   //  | 0x2b || 0x2f || 0x54 || 0x55 |
+        static const uint16_t am_profiles[][4] = {
+            // SHARP (ALPHA test profile) - Narrow IF filter (REG54 bits[14:8]=0, bits[7:0]=9), low IF gain (REG55 bits[11:8]=1, ref=169)
+            // Selective and crisp, best adjacent channel rejection, may sound harsh on strong signals
+            {0x0300, 0x9990, 0x9009, 0x31A9},
+
+            // STOCK - Narrow IF filter (REG54 bits[14:8]=0, bits[7:0]=9), moderate IF gain (REG55 bits[11:8]=4, ref=180)
+            // Selective filter with balanced gain, punchy and detailed, good compromise between rejection and sensitivity
+            {0x0500, 0x9990, 0x9009, 0x31A9},
+
+            // OPEN (BRAVO test profile) - Medium-wide IF filter (REG54 bits[14:8]=8, bits[7:0]=70), high IF gain (REG55 bits[11:8]=8, ref=192)
+            // Wide and pleasant, better sensitivity on weak signals, may struggle with adjacent channel interference
+            {0x0300, 0x9990, 0x8846, 0x38C0}
+        };
+
+        if (profile >= ARRAY_SIZE(am_profiles))
+            profile = 0;
+
+        BK4819_WriteRegister(0x2b, am_profiles[profile][0]);
+        BK4819_WriteRegister(0x2f, am_profiles[profile][1]);
+        BK4819_WriteRegister(0x54, am_profiles[profile][2]);
+        BK4819_WriteRegister(0x55, am_profiles[profile][3]);
     }
 
     static void AUDIO_ApplyUSBProfile(void)
@@ -859,12 +840,7 @@ void RADIO_SetupRegisters(bool switchToForeground)
 
     // AF RX Gain and DAC
     //BK4819_WriteRegister(BK4819_REG_48, 0xB3A8);  // 1011 00 111010 1000
-    BK4819_WriteRegister(BK4819_REG_48,
-        (11u << 12)                 |     // ??? .. 0 ~ 15, doesn't seem to make any difference
-        ( 0u << 10)                 |     // AF Rx Gain-1
-        (gEeprom.VOLUME_GAIN << 4) |     // AF Rx Gain-2
-        (gEeprom.DAC_GAIN    << 0));     // AF DAC Gain (after Gain-1 and Gain-2)
-
+    BK4819_SetRxAudioGain();
 
     uint16_t InterruptMask = BK4819_REG_3F_SQUELCH_FOUND | BK4819_REG_3F_SQUELCH_LOST;
 
@@ -1094,26 +1070,25 @@ void RADIO_SetTxParameters(void)
 void RADIO_SetModulation(ModulationMode_t modulation)
 {
     #ifdef ENABLE_BYP_RAW_DEMODULATORS
-    // BYP on BK4829 uses full audio bypass profile.
-    if (modulation == MODULATION_BYP) {
-        BK4819_EnterBypass();
+    if (modulation == MODULATION_BYP || modulation == MODULATION_RAW) {
+        uint16_t reg_3d_val = 0x0000;
+
+        if (modulation == MODULATION_BYP) {
+            // BYP on BK4829 uses full audio bypass profile.
+            BK4819_EnterBypass();
+            reg_3d_val = 0x2AAB;
+        } else {
+            // RAW on BK4829 uses RX-only filter bypass profile.
+            BK4819_EnterRaw();
+            // reg_3d_val = 0x0000;
+        }
+
         BK4819_SetRegValue(afDacGainRegSpec, 0xF);
-        BK4819_WriteRegister(BK4819_REG_3D, 0x2AAB);
+        BK4819_WriteRegister(BK4819_REG_3D, reg_3d_val);
         RADIO_SetupAGC(false, false);
         return;
     }
 
-    // RAW on BK4829 uses RX-only filter bypass profile.
-    if (modulation == MODULATION_RAW) {
-        BK4819_EnterRaw();
-        BK4819_SetRegValue(afDacGainRegSpec, 0xF);
-        BK4819_WriteRegister(BK4819_REG_3D, 0x0000);
-        RADIO_SetupAGC(false, false);
-        return;
-    }
-    #endif
-
-    #ifdef ENABLE_BYP_RAW_DEMODULATORS
     // Ensure we always leave bypass / raw mode before applying normal modulation settings.
     BK4819_ExitBypass();
     #endif

--- a/App/ui/menu.c
+++ b/App/ui/menu.c
@@ -1287,11 +1287,7 @@ void UI_DisplayMenu(void)
                     //#endif
                 }
                 // gEeprom.VOLUME_GAIN = gSubMenuSelection;
-                BK4819_WriteRegister(BK4819_REG_48,
-                    (11u << 12)                |     // ??? .. 0 ~ 15, doesn't seem to make any difference
-                    ( 0u << 10)                |     // AF Rx Gain-1
-                    (gEeprom.VOLUME_GAIN << 4) |     // AF Rx Gain-2
-                    (gEeprom.DAC_GAIN    << 0));     // AF DAC Gain (after Gain-1 and Gain-2)
+                BK4819_SetRxAudioGain();
                 break;
         #endif
 


### PR DESCRIPTION
**Hello.**

I’d like to present a code refactoring that saves 180 bytes. I’ve taken another shot at refactoring AUDIO_ApplyFMProfile and AUDIO_ApplyAMProfile. Just as I once tried to optimize the code by combining common register values from different profiles, you wrote:

>I am aware that your version is more optimized, but the current code makes it easier to maintain the settings for the different profiles. And since this section of the code is likely to undergo further adjustments, I would rather keep as much flexibility here as possible instead of trying to optimize it.

This time, I focused on the ability to flexibly modify values and improve readability. It turned out even better than what I did before.

I hope you like it, and I look forward to your feedback.