### PR TITLE
Reversing the up/down button functions on the Spectrum

### DIFF
--- a/App/app/spectrum.c
+++ b/App/app/spectrum.c
@@ -1490,7 +1490,7 @@ static void DrawArrow(uint8_t x)
 }
 
 static bool GetDirection(KEY_Code_t key) {
-    return (key == KEY_UP) ? !gEeprom.SET_NAV : gEeprom.SET_NAV;
+    return (key == KEY_UP) ? gEeprom.SET_NAV : !gEeprom.SET_NAV;
 }
 
 // Returns true if the key was handled (stop state-specific processing).


### PR DESCRIPTION
I didn't notice it, but during my last refactoring, I accidentally swapped the functions of the up and down buttons. It should be fixed now.