### PR TITLE
Add long-press functionality to ChName, minor refactoring

### DIFF
--- a/App/app/action.c
+++ b/App/app/action.c
@@ -343,22 +343,14 @@ void ACTION_Handle(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
             break;
     }
 
-    if (!bKeyHeld && bKeyPressed) // button pushed
-    {
+    if (bKeyHeld != bKeyPressed) { // button pushed or released after hold 
+                                   // (!bKeyHeld && bKeyPressed) or (bKeyHeld && !bKeyPressed)
         return;
     }
 
-    // held or released beyond this point
+    // held or released after short press
 
-    if(!(bKeyHeld && !bKeyPressed)) // don't beep on released after hold
-        gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
-
-    if (bKeyHeld && !bKeyPressed) // button released after hold
-    {
-        return;
-    }
-
-    // held or released after short press beyond this point
+    gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
     
 #ifdef ENABLE_FMRADIO
     if (gFmRadioMode) { // do not run these actions in FM radio mode

--- a/App/app/app.c
+++ b/App/app/app.c
@@ -2088,7 +2088,8 @@ static void ProcessKey(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
             }
         }
 #if defined(ENABLE_ALARM) || defined(ENABLE_TX1750)
-        else if ((!bKeyHeld && bKeyPressed) || (gAlarmState == ALARM_STATE_TX1750 && bKeyHeld && !bKeyPressed)) {
+        // else if ((!bKeyHeld && bKeyPressed) || (gAlarmState == ALARM_STATE_TX1750 && bKeyHeld && !bKeyPressed)) {
+        else if ((bKeyHeld != bKeyPressed) && (gAlarmState == ALARM_STATE_TX1750 || bKeyPressed)) {
             ALARM_Off();
 
             if (gEeprom.REPEATER_TAIL_TONE_ELIMINATION == 0)

--- a/App/app/menu.c
+++ b/App/app/menu.c
@@ -1507,6 +1507,13 @@ static const char* const char_map[10] = {
     "wxyz9"                         // KEY_9
 };
 
+static bool MENU_IsEditingName() {
+    return !gCssBackgroundScan
+        && UI_MENU_GetCurrentMenuId() == MENU_MEM_NAME
+        && gIsInSubMenu
+        && edit_index >= 0;
+}
+
 static void MENU_Key_0_to_9(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 {
     uint8_t  Offset;
@@ -1708,12 +1715,7 @@ static void MENU_Key_0_to_9(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 
 static void MENU_Key_EXIT(bool bKeyPressed, bool bKeyHeld)
 {
-    const bool editing_name = !gCssBackgroundScan
-        && UI_MENU_GetCurrentMenuId() == MENU_MEM_NAME
-        && gIsInSubMenu
-        && edit_index >= 0;
-
-    if (editing_name)
+    if (MENU_IsEditingName())
     {
         if (!bKeyPressed)
         {
@@ -1813,9 +1815,9 @@ Skip:
 
 static void MENU_Key_MENU(const bool bKeyPressed, const bool bKeyHeld)
 {
-    if (bKeyHeld || !bKeyPressed)
+    if (!bKeyPressed || (bKeyHeld && (!MENU_IsEditingName() || gAskForConfirmation)))
         return;
-
+    
     gBeepToPlay           = BEEP_1KHZ_60MS_OPTIONAL;
     gRequestDisplayScreen = DISPLAY_MENU;
 
@@ -1884,8 +1886,12 @@ static void MENU_Key_MENU(const bool bKeyPressed, const bool bKeyHeld)
         {   // editing the channel name characters
             edit_last_key = 255;
 
-            if (++edit_index < 10)
-                return; // next char
+            if (bKeyHeld) {
+                edit_index = 10;
+            }
+            else if (++edit_index < 10) {
+                return;
+            }
 
             // exit
             gFlagAcceptSetting  = false;
@@ -2013,22 +2019,17 @@ static void MENU_Key_UP_DOWN(bool bKeyPressed, bool bKeyHeld, int8_t Direction)
     uint16_t Channel;
     bool    bCheckScanList;
 
+    if (!bKeyPressed)
+        return;
+
+    if (!bKeyHeld) {
+        gInputBoxIndex = 0;
+        gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
+    }
+
     if (!gEeprom.SET_NAV && gIsInSubMenu) {
         Direction = -Direction;
     }
-
-    if (!bKeyHeld)
-    {
-        if (!bKeyPressed)
-            return;
-
-        gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
-
-        gInputBoxIndex = 0;
-    }
-    else
-    if (!bKeyPressed)
-        return;
 
     if (UI_MENU_GetCurrentMenuId() == MENU_MEM_NAME && gIsInSubMenu && edit_index >= 0)
     {   // change the character

--- a/App/app/scanner.c
+++ b/App/app/scanner.c
@@ -243,16 +243,13 @@ static void SCANNER_Key_STAR(bool bKeyPressed, bool bKeyHeld)
     return;
 }
 
-static void SCANNER_Key_UP_DOWN(bool bKeyPressed, bool pKeyHeld, int8_t Direction)
+static void SCANNER_Key_UP_DOWN(bool bKeyPressed, bool bKeyHeld, int8_t Direction)
 {
-    if (pKeyHeld) {
-        if (!bKeyPressed)
-            return;
+    if (!bKeyPressed) {
+        return;
     }
-    else {
-        if (!bKeyPressed)
-            return;
 
+    if (!bKeyHeld) {
         gInputBoxIndex = 0;
         gBeepToPlay    = BEEP_1KHZ_60MS_OPTIONAL;
     }
@@ -266,7 +263,7 @@ static void SCANNER_Key_UP_DOWN(bool bKeyPressed, bool pKeyHeld, int8_t Directio
         gShowChPrefix         = RADIO_CheckValidChannel(gScanChannel, false, 0);
         gRequestDisplayScreen = DISPLAY_SCANNER;
     }
-    else
+    else if (!bKeyHeld)
         gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
 }
 


### PR DESCRIPTION
**Hello.**

I was inspired by a comment from a user under your new video about the new v5.4.0 version, where they suggested that it would be a good idea to add a long press of the MENU button so you don’t have to click several times to reach the end of the index. I thought it was a good idea and decided to implement it:

<img width="1350" height="74" alt="image" src="https://github.com/user-attachments/assets/987a2252-109b-4c50-b72d-0fd7ca7c7079" />



<details>
  <summary>By the way...</summary>

This user also wrote that it would be a good idea to navigate through characters using the arrow keys - in my opinion, that’s not really an option, because as I wrote:

> “I kept the arrow-based character input as before, because some users (especially those with the UV-K5 model) may have trouble with the new input system.”
</details>

In addition, I did a “minor” refactoring in a few places related to checking bKeyPressed and pKeyHeld.

I hope you like it.