### PR TITLE
Show DCS codes from 39 to 121; Code refactoring (16 B)

### DIFF
--- a/App/dcs.c
+++ b/App/dcs.c
@@ -14,6 +14,7 @@
  *     limitations under the License.
  */
 
+#include <stddef.h>
 #include "dcs.h"
 #include "misc.h"
 
@@ -122,18 +123,18 @@ uint8_t DCS_GetCtcssCode(int Code)
     return Result;
 }
 
-uint8_t DCS_GetCtcssApprovedIndex(uint8_t Option)
+static uint8_t DCS_GetApprovedIndex(uint8_t Option, size_t options_size, size_t extraidx_size, const uint8_t *extraidx)
 {
     unsigned int i;
     unsigned int extra_pos = 0;
     uint8_t approved_index = 0;
 
-    if (Option >= ARRAY_SIZE(CTCSS_Options))
+    if (Option >= options_size)
         return 0xFF;
 
-    for (i = 0; i < ARRAY_SIZE(CTCSS_Options); i++) {
-        const bool is_extra = extra_pos < ARRAY_SIZE(CTCSS_ExtraIdx) &&
-                              i == CTCSS_ExtraIdx[extra_pos];
+    for (i = 0; i < options_size; i++) {
+        const bool is_extra = extra_pos < extraidx_size &&
+                              i == extraidx[extra_pos];
 
         if (is_extra) {
             extra_pos++;
@@ -149,29 +150,12 @@ uint8_t DCS_GetCtcssApprovedIndex(uint8_t Option)
     return 0xFF;
 }
 
+uint8_t DCS_GetCtcssApprovedIndex(uint8_t Option)
+{
+    return DCS_GetApprovedIndex(Option, ARRAY_SIZE(CTCSS_Options), ARRAY_SIZE(CTCSS_ExtraIdx), CTCSS_ExtraIdx);
+}
+
 uint8_t DCS_GetDcsApprovedIndex(uint8_t Option)
 {
-    unsigned int i;
-    unsigned int extra_pos = 0;
-    uint8_t approved_index = 0;
-
-    if (Option >= ARRAY_SIZE(DCS_Options))
-        return 0xFF;
-
-    for (i = 0; i < ARRAY_SIZE(DCS_Options); i++) {
-        const bool is_extra = extra_pos < ARRAY_SIZE(DCS_ExtraIdx) &&
-                              i == DCS_ExtraIdx[extra_pos];
-
-        if (is_extra) {
-            extra_pos++;
-            continue;
-        }
-
-        if (i == Option)
-            return approved_index;
-
-        approved_index++;
-    }
-
-    return 0xFF;
+    return DCS_GetApprovedIndex(Option, ARRAY_SIZE(DCS_Options), ARRAY_SIZE(DCS_ExtraIdx), DCS_ExtraIdx);
 }

--- a/App/ui/menu.c
+++ b/App/ui/menu.c
@@ -593,6 +593,8 @@ void UI_DisplayMenu(void)
     char               String[64];  // bigger cuz we can now do multi-line in one string (use '\n' char)
     char               top_right_badge[16];
 
+    const int m = UI_MENU_GetCurrentMenuId();
+
 #ifdef ENABLE_DTMF_CALLING
     char               Contact[16];
 #endif
@@ -706,7 +708,7 @@ void UI_DisplayMenu(void)
         uint8_t gaugeMax = 0;
     //#endif
 
-    switch (UI_MENU_GetCurrentMenuId())
+    switch (m)
     {
         case MENU_SQL:
             sprintf(String, "%d", gSubMenuSelection);
@@ -1059,7 +1061,7 @@ void UI_DisplayMenu(void)
         case MENU_S_LIST:
             if (gSubMenuSelection == MR_CHANNELS_LIST + 1)
                 strcpy(String, "ALL");
-            else if (gSubMenuSelection == 0 && UI_MENU_GetCurrentMenuId() == MENU_LIST_CH)
+            else if (gSubMenuSelection == 0 && m == MENU_LIST_CH)
                 strcpy(String, "OFF");
             else {
                 const char *name = gListName[gSubMenuSelection - 1];
@@ -1466,16 +1468,16 @@ void UI_DisplayMenu(void)
         }
     }
 
-    if (UI_MENU_GetCurrentMenuId() == MENU_S_PRI_CH_1 || UI_MENU_GetCurrentMenuId() == MENU_S_PRI_CH_2)
+    if (m == MENU_S_PRI_CH_1 || m == MENU_S_PRI_CH_2)
     {
 
     }
 
-    if ((UI_MENU_GetCurrentMenuId() == MENU_R_CTCS || UI_MENU_GetCurrentMenuId() == MENU_R_DCS) && gCssBackgroundScan)
+    if ((m == MENU_R_CTCS || m == MENU_R_DCS) && gCssBackgroundScan)
         UI_PrintString("SCAN", menu_item_x1, menu_item_x2, 4, 8);
 
 #ifdef ENABLE_DTMF_CALLING
-    if (UI_MENU_GetCurrentMenuId() == MENU_D_LIST && gIsDtmfContactValid) {
+    if (m == MENU_D_LIST && gIsDtmfContactValid) {
         Contact[11] = 0;
         memcpy(&gDTMF_ID, Contact + 8, 4);
         sprintf(String, "ID:%4s", gDTMF_ID);
@@ -1483,51 +1485,46 @@ void UI_DisplayMenu(void)
     }
 #endif
 
-    if (UI_MENU_GetCurrentMenuId() == MENU_R_CTCS ||
-        UI_MENU_GetCurrentMenuId() == MENU_T_CTCS ||
-        UI_MENU_GetCurrentMenuId() == MENU_R_DCS  ||
-        UI_MENU_GetCurrentMenuId() == MENU_T_DCS
-#ifdef ENABLE_DTMF_CALLING
-        || UI_MENU_GetCurrentMenuId() == MENU_D_LIST
-#endif
-    ) {
-        if (UI_MENU_GetCurrentMenuId() == MENU_R_CTCS ||
-            UI_MENU_GetCurrentMenuId() == MENU_T_CTCS) {
-            const uint8_t approved_index =
-                (gSubMenuSelection > 0) ? DCS_GetCtcssApprovedIndex(gSubMenuSelection - 1) : 0xFF;
+    if (m == MENU_R_CTCS ||
+        m == MENU_T_CTCS) {
+        const uint8_t approved_index =
+            (gSubMenuSelection > 0) ? DCS_GetCtcssApprovedIndex(gSubMenuSelection - 1) : 0xFF;
 
-            if (gSubMenuSelection == 0)
-                sprintf(top_right_badge, "00/00");
-            else if (approved_index != 0xFF)
-                sprintf(top_right_badge, "%02u/%02u", (unsigned)gSubMenuSelection, (unsigned)approved_index + 1);
-            else
-                sprintf(top_right_badge, "%02u/--", (unsigned)gSubMenuSelection);
-        } else if (UI_MENU_GetCurrentMenuId() == MENU_R_DCS ||
-                   UI_MENU_GetCurrentMenuId() == MENU_T_DCS) {
-            const bool is_normal_dcs =
-                gSubMenuSelection > 0 && gSubMenuSelection <= ARRAY_SIZE(DCS_Options);
-            const uint8_t approved_index =
-                is_normal_dcs ? DCS_GetDcsApprovedIndex(gSubMenuSelection - 1) : 0xFF;
-
-            if (gSubMenuSelection == 0)
-                sprintf(top_right_badge, "000/000");
-            else if (approved_index != 0xFF)
-                sprintf(top_right_badge, "%03u/%03u", (unsigned)gSubMenuSelection, (unsigned)approved_index + 1);
-            else
-                sprintf(top_right_badge, "%03u/---", (unsigned)gSubMenuSelection);
-        } else {
-            sprintf(top_right_badge, "%03d", gSubMenuSelection);
-        }
+        if (gSubMenuSelection == 0)
+            sprintf(top_right_badge, "00/00");
+        else if (approved_index != 0xFF)
+            sprintf(top_right_badge, "%02u/%02u", (unsigned)gSubMenuSelection, (unsigned)approved_index + 1);
+        else
+            sprintf(top_right_badge, "%02u/--", (unsigned)gSubMenuSelection);
     }
+    
+    if (m == MENU_R_DCS ||
+        m == MENU_T_DCS) {
+        const uint8_t approved_index =
+            (gSubMenuSelection > 0) ? DCS_GetDcsApprovedIndex(gSubMenuSelection - 1) : 0xFF;
+
+        if (gSubMenuSelection == 0)
+            sprintf(top_right_badge, "000/000");
+        else if (approved_index != 0xFF)
+            sprintf(top_right_badge, "%03u/%03u", (unsigned)gSubMenuSelection, (unsigned)approved_index + 39);
+        else
+            sprintf(top_right_badge, "%03u/---", (unsigned)gSubMenuSelection);
+    }
+
+#ifdef ENABLE_DTMF_CALLING
+    if (m == MENU_D_LIST) {
+        sprintf(top_right_badge, "%03d", gSubMenuSelection);
+    }
+#endif
 
     if (top_right_badge[0] != '\0') {
         UI_MENU_DrawTopRightRoundedBadge(top_right_badge, 1, true, menu_item_x1, menu_item_x2);
     }
 
-    if ((UI_MENU_GetCurrentMenuId() == MENU_RESET    ||
-         UI_MENU_GetCurrentMenuId() == MENU_MEM_CH   ||
-         UI_MENU_GetCurrentMenuId() == MENU_MEM_NAME ||
-         UI_MENU_GetCurrentMenuId() == MENU_DEL_CH) && gAskForConfirmation)
+    if ((m == MENU_RESET    ||
+         m == MENU_MEM_CH   ||
+         m == MENU_MEM_NAME ||
+         m == MENU_DEL_CH) && gAskForConfirmation)
     {   // display confirmation
         char *pPrintStr = (gAskForConfirmation == 1) ? "SURE?" : "WAIT!";
         UI_PrintString(pPrintStr, menu_item_x1, menu_item_x2, 5, 8);

--- a/App/ui/menu.c
+++ b/App/ui/menu.c
@@ -1506,7 +1506,7 @@ void UI_DisplayMenu(void)
         if (gSubMenuSelection == 0)
             sprintf(top_right_badge, "000/000");
         else if (approved_index != 0xFF)
-            sprintf(top_right_badge, "%03u/%03u", (unsigned)gSubMenuSelection, (unsigned)approved_index + 39);
+            sprintf(top_right_badge, "%03u/%03u", (unsigned)gSubMenuSelection, (unsigned)approved_index + 1);
         else
             sprintf(top_right_badge, "%03u/---", (unsigned)gSubMenuSelection);
     }


### PR DESCRIPTION
**Hello.**

I was inspired by the discussion at https://github.com/armel/uv-k1-k5v3-firmware-custom/discussions/321 and decided to try adding DCS indexes, but you beat me to it :)

However, I decided to make a pull request because I thought it could be done a little better, even though there’s no difference in the size of the binary code (the magic of C++). I also managed to do a little refactoring.

I also added support for displaying DCS indexes from 039 to 121, just as the codes are.

I hope you like it.