### PR TITLE
Displaying VFO_Lock on the second channel while receiving on the first; Code refactoring (42 B)

### DIFF
--- a/App/app/action.c
+++ b/App/app/action.c
@@ -239,7 +239,6 @@ void ACTION_Scan(bool bRestart)
         // channel mode. Keep scanning but toggle between scan lists
         RADIO_NextValidList(1);
         UI_MAIN_NotifyScanProgressDataChanged();
-        gUpdateStatus = true;
 
         #ifdef ENABLE_FEAT_F4HWN_RESUME_STATE
             SETTINGS_WriteCurrentState();

--- a/App/app/chFrScanner.c
+++ b/App/app/chFrScanner.c
@@ -646,7 +646,6 @@ void CHFRSCANNER_Start(const bool storeBackupSettings, const int8_t scan_directi
         if(!RADIO_CheckValidList(gEeprom.SCAN_LIST_DEFAULT)) {
             RADIO_NextValidList(1);
             UI_MAIN_NotifyScanProgressDataChanged();
-            gUpdateStatus = true;
         }
 
         // channel mode

--- a/App/app/main.c
+++ b/App/app/main.c
@@ -301,7 +301,6 @@ static void processFKeyFunction(const KEY_Code_t Key, const bool beep)
                 if (gScanStateDir != SCAN_OFF) {
                     RADIO_NextValidList(isKeyUp ? 1 : -1);
                     UI_MAIN_NotifyScanProgressDataChanged();
-                    gUpdateStatus = true;
                 } else {
                     // Adjust squelch: UP increments, DOWN decrements
                     if (gSquelchLevelOriginal == 10)
@@ -485,7 +484,6 @@ static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
             {
                 gEeprom.SCAN_LIST_DEFAULT = MR_CHANNELS_LIST + 1;
                 UI_MAIN_NotifyScanProgressDataChanged();
-                gUpdateStatus = true;
             #ifdef ENABLE_FEAT_F4HWN_RESUME_STATE
                 SETTINGS_WriteCurrentState();
             #endif
@@ -505,7 +503,6 @@ static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
                     RADIO_NextValidList(1);
                 }
                 UI_MAIN_NotifyScanProgressDataChanged();
-                gUpdateStatus = true;
 
             #ifdef ENABLE_FEAT_F4HWN_RESUME_STATE
                 SETTINGS_WriteCurrentState();

--- a/App/ui/main.c
+++ b/App/ui/main.c
@@ -108,6 +108,7 @@ static void ScanProgress_ResetSession(void)
 void UI_MAIN_NotifyScanProgressDataChanged(void)
 {
     gScanProgressForceRebuild = true;
+    gUpdateStatus = true;
 }
 
 static inline void ScanProgress_SetBit(uint8_t *map, uint16_t ch)
@@ -1302,14 +1303,6 @@ void UI_DisplayMain(void)
 
         uint32_t frequency = gEeprom.VfoInfo[vfo_num].pRX->Frequency;
 
-        if(TX_freq_check(frequency) != 0 && gEeprom.VfoInfo[vfo_num].TX_LOCK == true && !FUNCTION_IsRx())
-        {
-            if(isMainOnly())
-                memcpy(p_line0 + 25, BITMAP_VFO_Lock, sizeof(BITMAP_VFO_Lock));
-            else
-                memcpy(p_line0 + 25, BITMAP_VFO_Lock, sizeof(BITMAP_VFO_Lock));
-        }
-
         if (gCurrentFunction == FUNCTION_TRANSMIT)
         {   // transmitting
 
@@ -1391,6 +1384,12 @@ void UI_DisplayMain(void)
                     RxBlinkLed = 2;
             }
 #endif
+        }
+
+        if(TX_freq_check(frequency) != 0 && gEeprom.VfoInfo[vfo_num].TX_LOCK == true)
+        {
+            if (!FUNCTION_IsRx() || RxOnVfofrequency != frequency)
+                memcpy(p_line0 + 25, BITMAP_VFO_Lock, sizeof(BITMAP_VFO_Lock));
         }
 
         if (IS_MR_CHANNEL(gEeprom.ScreenChannel[vfo_num]))


### PR DESCRIPTION
**Hello.**

I did a little refactoring by adding ``gUpdateStatus = true`` into the function ``UI_MAIN_NotifyScanProgressDataChanged()``. 

I mainly focused on the fact that in the last video where you showed that the two-channel transition doesn't appear during scanning, I noticed a flashing padlock icon on the second channel:

<img width="270" height="480" alt="586883366-25804def-0745-4c87-adcf-e97ed2aeb9d1-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/56bb319c-9417-47fd-9ebc-dc177629ad10" />



I set it up so that if we’re receiving RX on the first channel, the padlock will appear on the second channel if necessary:
<img width="704" height="384" alt="image" src="https://github.com/user-attachments/assets/d3b919f4-b065-4f96-a0c4-fdf5cd93ab28" />


I hope you like it.