### PR TITLE
Code refactoring (288 B)

### DIFF
--- a/App/app/spectrum.c
+++ b/App/app/spectrum.c
@@ -1604,7 +1604,7 @@ static void ShowChannelName(uint32_t f)
         if (f != channelF) {
             channelF = f;
             unsigned int i;
-            memset(channelName, 0, sizeof(channelName));
+            channelName[0] = 0;
             for (i = 0; IS_MR_CHANNEL(i); i++)
             {
                 if (RADIO_CheckValidChannel(i, false, 0))
@@ -1715,16 +1715,7 @@ static bool SpectrumColumnAtOrAboveY(const uint8_t *topY, uint8_t x, uint8_t y)
 
 static uint8_t GetScanStepTextWidth()
 {
-    uint16_t whole = GetScanStep() / 100;
-    uint8_t digits = 1;
-
-    while (whole >= 10)
-    {
-        whole /= 10;
-        digits++;
-    }
-
-    return (digits + 4) * 4; // "%u.%02uk", 4 px advance per char
+    return (sprintf(NULL, "%u", GetScanStep() / 100) + 4) * 4; // "%u.%02uk", 4 px advance per char
 }
 
 static void DrawRssiTriggerLevel(const uint8_t *topY)

--- a/App/ui/aircopy.c
+++ b/App/ui/aircopy.c
@@ -37,9 +37,8 @@ static int get_bit(uint8_t* array, int bit_index) {
 
 void UI_DisplayAircopy(void)
 {
-    char String[16] = { 0 };
-    char *pPrintStr = { 0 };
-    uint16_t percent;
+    char String[16];
+    char *pPrintStr;
 
     UI_DisplayClear();
 
@@ -60,15 +59,13 @@ void UI_DisplayAircopy(void)
         // show the remaining 2 small frequency digits
         UI_PrintStringSmallNormal(String + 7, 97, 0, 3);
         String[7] = 0;
-        // show the main large frequency digits
-        UI_DisplayFrequency(String, 16, 2, false);
     } else {
         const char *ascii = INPUTBOX_GetAscii();
         sprintf(String, "%.3s.%.3s", ascii, ascii + 3);
-        UI_DisplayFrequency(String, 16, 2, false);
     }
 
-    memset(String, 0, sizeof(String));
+    // show the main large frequency digits
+    UI_DisplayFrequency(String, 16, 2, false);
 
     // Get the current map and calculate percentage based on its total blocks
     const AIRCOPY_TransferMap_t *currentMap = AIRCOPY_GetCurrentMap();
@@ -78,47 +75,44 @@ void UI_DisplayAircopy(void)
     if (doneBlocks > currentMap->total_blocks)
         doneBlocks = currentMap->total_blocks;
 
-    percent = (doneBlocks * 10000) / currentMap->total_blocks;
-
-    if (gAirCopyIsSendMode == 0) {
-        sprintf(String, "RCV:%02u.%02u%% E:%d", percent / 100, percent % 100, gErrorsDuringAirCopy);
-    } else if (gAirCopyIsSendMode == 1) {
-        sprintf(String, "SND:%02u.%02u%%", percent / 100, percent % 100);
-    }
-
-    // Draw gauge
-    if(gAircopyStep != 0)
-    {
-        UI_PrintString(String, 2, 127, 5, 8);
-
-        gFrameBuffer[4][1] = 0x3c;
-        gFrameBuffer[4][2] = 0x42;
-
-        for(uint8_t i = 1; i <= AIRCOPY_BAR_WIDTH + 2; i++)
-        {
-            gFrameBuffer[4][2 + i] = 0x81;
-        }
-
-        gFrameBuffer[4][125] = 0x42;
-        gFrameBuffer[4][126] = 0x3c;
-    }
-    
     // Draw memory selection
-    if(gAircopyState == AIRCOPY_READY)
+    if (gAircopyState == AIRCOPY_READY) 
     {
         doneBlocks = 0;
 
-        memset(gFrameBuffer[5], 0, 128);
-        memset(gFrameBuffer[6], 0, 128);
-
         if(gAircopyCurrentMapIndex < AIRCOPY_NUM_BANKS) {   
-            sprintf(String, "MEM %03u - %03u%", (gAircopyCurrentMapIndex * 128) + 1, (gAircopyCurrentMapIndex + 1) * 128);
-        }
-        else
-        {
-            sprintf(String, "Settings");            
+            sprintf(String, "MEM %03u - %03u", (gAircopyCurrentMapIndex * 128) + 1, (gAircopyCurrentMapIndex + 1) * 128);
+        } else {
+            strcpy(String, "Settings");            
         }
         UI_PrintString(String, 2, 127, 5, 8);
+    } 
+    else 
+    {
+        uint16_t percent = (doneBlocks * 10000) / currentMap->total_blocks;
+
+        if (gAirCopyIsSendMode == 0) {
+            sprintf(String, "RCV:%02u.%02u%% E:%d", percent / 100, percent % 100, gErrorsDuringAirCopy);
+        } else {
+            sprintf(String, "SND:%02u.%02u%%", percent / 100, percent % 100);
+        }
+
+        // Draw gauge
+        if(gAircopyStep != 0)
+        {
+            UI_PrintString(String, 2, 127, 5, 8);
+
+            gFrameBuffer[4][1] = 0x3c;
+            gFrameBuffer[4][2] = 0x42;
+
+            for(uint8_t i = 1; i <= AIRCOPY_BAR_WIDTH + 2; i++)
+            {
+                gFrameBuffer[4][2 + i] = 0x81;
+            }
+
+            gFrameBuffer[4][125] = 0x42;
+            gFrameBuffer[4][126] = 0x3c;
+        }
     }
 
     if (doneBlocks > 0)
@@ -131,19 +125,12 @@ void UI_DisplayAircopy(void)
             lErrorsDuringAirCopy = gErrorsDuringAirCopy;
         }
 
-        const AIRCOPY_TransferMap_t *currentMap = AIRCOPY_GetCurrentMap();
-
-        uint16_t total = currentMap->total_blocks;
-        uint16_t done  = gAirCopyBlockNumber + gErrorsDuringAirCopy;
-        
-        if (done > total) done = total;
+        uint16_t b = 0;
+        uint16_t fraction_accumulator = 0;
 
         for (uint8_t col = 0; col < AIRCOPY_BAR_WIDTH; col++)
         {
-            /* Map column [0..BAR_WIDTH-1] to block [0..total-1] */
-            uint16_t b = (uint16_t)((col * (uint32_t)total) / AIRCOPY_BAR_WIDTH);
-
-            bool processed = (b < done);
+            bool processed = (b < doneBlocks);
             bool error     = processed && get_bit(crc, b);
 
             if (!processed)
@@ -152,8 +139,14 @@ void UI_DisplayAircopy(void)
                 gFrameBuffer[4][col + 4] = 0x81;   // error gap (intentional hole)
             else
                 gFrameBuffer[4][col + 4] = 0xBD;   // ok filled
-        }
 
+            // DDA/Bresenham algorythm
+            fraction_accumulator += currentMap->total_blocks;
+            while (fraction_accumulator >= AIRCOPY_BAR_WIDTH) {
+                fraction_accumulator -= AIRCOPY_BAR_WIDTH;
+                b++;
+            }
+        }
     }
 
     ST7565_BlitFullScreen();

--- a/App/ui/fmradio.c
+++ b/App/ui/fmradio.c
@@ -31,7 +31,7 @@
 
 void UI_DisplayFM(void)
 {
-    char String[16] = {0};
+    char String[16];
     char *pPrintStr = String;
     UI_DisplayClear();
 
@@ -80,7 +80,6 @@ void UI_DisplayFM(void)
 
     UI_PrintString(pPrintStr, 0, 127, 3, 10); // memory, vfo, scan
 
-    memset(String, 0, sizeof(String));
     if (gAskToSave || (gEeprom.FM_IsMrMode && gInputBoxIndex > 0)) {
         UI_GenerateChannelString(String, gFM_ChannelPosition);
     } else if (gAskToDelete) {

--- a/App/ui/helper.c
+++ b/App/ui/helper.c
@@ -40,6 +40,8 @@ void UI_GenerateChannelString(char *pString, const uint16_t Channel)
     pString[2] = '-';
     for (i = 0; i < 2; i++)
         pString[i + 3] = (gInputBox[i] == 10) ? '-' : gInputBox[i] + '0';
+
+    pString[5] = 0;
 }
 
 void UI_GenerateChannelStringEx(char *pString, const bool bShowPrefix, const uint16_t ChannelNumber)

--- a/App/ui/main.c
+++ b/App/ui/main.c
@@ -321,16 +321,9 @@ static void ScanProgress_DrawGaugeLine(uint8_t line, uint32_t current_index, uin
     }
 }
 
-static uint8_t ScanProgress_DecimalDigits(uint32_t value)
+static inline uint8_t ScanProgress_DecimalDigits(uint32_t value)
 {
-    uint8_t digits = 1;
-
-    while (value >= 10u) {
-        value /= 10u;
-        digits++;
-    }
-
-    return digits;
+    return sprintf(NULL, "%u", value);
 }
 
 static void ScanProgress_FormatIndex(char *out, size_t out_size, uint32_t current_index, uint32_t total, uint8_t width)

--- a/App/ui/menu.c
+++ b/App/ui/menu.c
@@ -228,10 +228,7 @@ const char* const gSubMenu_OFF_ON[] =
     "ON"
 };
 
-const char* const gSubMenu_NA[] =
-{
-    "N/A"
-};
+const char* gSubMenu_NA = "N/A";
 
 const char* const gSubMenu_RXMode[] =
 {

--- a/App/ui/menu.c
+++ b/App/ui/menu.c
@@ -197,7 +197,7 @@ const t_menu_item MenuList[] =
 
 const uint8_t FIRST_HIDDEN_MENU_ITEM = MENU_F_LOCK;
 
-const char gSubMenu_TXP[][6] =
+const char* const gSubMenu_TXP[] =
 {
     "USER",
     "LOW 1",
@@ -209,26 +209,26 @@ const char gSubMenu_TXP[][6] =
     "HIGH"
 };
 
-const char gSubMenu_SFT_D[][4] =
+const char* const gSubMenu_SFT_D[] =
 {
     "OFF",
     "+",
     "-"
 };
 
-const char gSubMenu_W_N[][7] =
+const char* const gSubMenu_W_N[] =
 {
     "WIDE",
     "NARROW"
 };
 
-const char gSubMenu_OFF_ON[][4] =
+const char* const gSubMenu_OFF_ON[] =
 {
     "OFF",
     "ON"
 };
 
-const char gSubMenu_NA[4] =
+const char* const gSubMenu_NA[] =
 {
     "N/A"
 };
@@ -242,7 +242,7 @@ const char* const gSubMenu_RXMode[] =
 };
 
 #ifdef ENABLE_VOICE
-    const char gSubMenu_VOICE[][4] =
+    const char* const gSubMenu_VOICE[] =
     {
         "OFF",
         "CHI",
@@ -259,7 +259,7 @@ const char* const gSubMenu_MDF[] =
 };
 
 #ifdef ENABLE_ALARM
-    const char gSubMenu_AL_MOD[][5] =
+    const char* const gSubMenu_AL_MOD[] =
     {
         "SITE",
         "TONE"
@@ -267,7 +267,7 @@ const char* const gSubMenu_MDF[] =
 #endif
 
 #ifdef ENABLE_DTMF_CALLING
-const char gSubMenu_D_RSP[][11] =
+const char* const gSubMenu_D_RSP[] =
 {
     "DO\nNOTHING",
     "RING",
@@ -285,7 +285,7 @@ const char* const gSubMenu_PTT_ID[] =
     "APOLLO\nQUINDAR"
 };
 
-const char gSubMenu_PONMSG[][8] =
+const char* const gSubMenu_PONMSG[] =
 {
 #ifdef ENABLE_FEAT_F4HWN
     "ALL",
@@ -301,20 +301,20 @@ const char gSubMenu_PONMSG[][8] =
     "NONE"
 };
 
-const char gSubMenu_ROGER[][6] =
+const char* const gSubMenu_ROGER[] =
 {
     "OFF",
     "ROGER",
     "MDC"
 };
 
-const char gSubMenu_RESET[][4] =
+const char* const gSubMenu_RESET[] =
 {
     "VFO",
     "ALL"
 };
 
-const char * const gSubMenu_F_LOCK[] =
+const char* const gSubMenu_F_LOCK[] =
 {
     "DEFAULT+\n137-174\n400-470",
     "FCC HAM\n144-148\n420-450",
@@ -335,7 +335,7 @@ const char * const gSubMenu_F_LOCK[] =
     "UNLOCK\nALL",
 };
 
-const char gSubMenu_RX_TX[][6] =
+const char* const gSubMenu_RX_TX[] =
 {
     "OFF",
     "TX",
@@ -343,14 +343,14 @@ const char gSubMenu_RX_TX[][6] =
     "TX/RX"
 };
 
-const char gSubMenu_BAT_TXT[][8] =
+const char* const gSubMenu_BAT_TXT[] =
 {
     "NONE",
     "VOLTAGE",
     "PERCENT"
 };
 
-const char gSubMenu_BATTYP[][12] =
+const char* const gSubMenu_BATTYP[] =
 {
     "1600mAh K5",
     "2200mAh K5",
@@ -359,14 +359,14 @@ const char gSubMenu_BATTYP[][12] =
     "2500mAh K1"
 };
 
-const char gSubMenu_SET_NAV[][17] =
+const char* const gSubMenu_SET_NAV[] =
 {
     "LEFT\nRIGHT\nUV-K1",
     "UP\nDOWN\nUV-K5(8)",
 };
 
 #ifndef ENABLE_FEAT_F4HWN
-const char gSubMenu_SCRAMBLER[][7] =
+const char* const gSubMenu_SCRAMBLER[] =
 {
     "OFF",
     "2600Hz",
@@ -383,7 +383,7 @@ const char gSubMenu_SCRAMBLER[][7] =
 #endif
 
 #ifdef ENABLE_FEAT_F4HWN
-    const char gSubMenu_SET_PWR[][6] =
+    const char* const gSubMenu_SET_PWR[] =
     {
         "< 20m",
         "125m",
@@ -394,13 +394,13 @@ const char gSubMenu_SCRAMBLER[][7] =
         "5"
     };
 
-    const char gSubMenu_SET_PTT[][8] =
+    const char* const gSubMenu_SET_PTT[] =
     {
         "CLASSIC",
         "ONEPUSH"
     };
 
-    const char gSubMenu_SET_TOT[][7] =  // Use by SET_EOT too
+    const char* const gSubMenu_SET_TOT[] =  
     {
         "OFF",
         "SOUND",
@@ -408,20 +408,20 @@ const char gSubMenu_SCRAMBLER[][7] =
         "ALL"
     };
 
-    const char gSubMenu_SET_LCK[][9] =
+    const char* const gSubMenu_SET_LCK[] =
     {
         "KEYS",
         "KEYS+PTT"
     };
 
-    const char gSubMenu_SET_MET[][8] =
+    const char* const gSubMenu_SET_MET[] =
     {
         "TINY",
         "CLASSIC"
     };
 
     #ifdef ENABLE_FEAT_F4HWN_SCAN_FASTER
-        const char gSubMenu_SET_SCN[][7] =
+        const char* const gSubMenu_SET_SCN[] =
         {
             "NORMAL",
             "FAST"
@@ -429,7 +429,7 @@ const char gSubMenu_SCRAMBLER[][7] =
     #endif
 
     #ifdef ENABLE_FEAT_F4HWN_AUDIO
-        const char gSubMenu_SET_AUD_FM[][6] =
+        const char* const gSubMenu_SET_AUD_FM[] =
         {
             "FLAT",
             "CLEAN",
@@ -438,7 +438,7 @@ const char gSubMenu_SCRAMBLER[][7] =
             "MAX"
         };
 
-        const char gSubMenu_SET_AUD_AM[][6] =
+        const char* const gSubMenu_SET_AUD_AM[] =
         {
             "SHARP",
             "STOCK",
@@ -447,7 +447,7 @@ const char gSubMenu_SCRAMBLER[][7] =
     #endif
 
     #ifdef ENABLE_FEAT_F4HWN_NARROWER
-        const char gSubMenu_SET_NFM[][9] =
+        const char* const gSubMenu_SET_NFM[] =
         {
             "NARROW",
             "NARROWER"
@@ -455,7 +455,7 @@ const char gSubMenu_SCRAMBLER[][7] =
     #endif
 
     #ifdef ENABLE_FEAT_F4HWN_RESCUE_OPS
-        const char gSubMenu_SET_KEY[][9] =
+        const char* const gSubMenu_SET_KEY[] =
         {
             "KEY_MENU",
             "KEY_UP",
@@ -496,7 +496,7 @@ const t_sidefunction gSubMenu_SIDEFUNCTIONS[] =
     {"VFO\nMEM",        ACTION_OPT_VFO_MR},
     {"MODE",            ACTION_OPT_SWITCH_DEMODUL},
 #ifdef ENABLE_BLMIN_TMP_OFF
-    {"BLMIN\nTMP OFF",  ACTION_OPT_BLMIN_TMP_OFF},      //BackLight Minimum Temporay OFF
+    {"BLMIN\nTMP OFF",  ACTION_OPT_BLMIN_TMP_OFF},      //BackLight Minimum Temporary OFF
 #endif
 #ifdef ENABLE_FEAT_F4HWN
     {"RX MODE",         ACTION_OPT_RXMODE},
@@ -658,58 +658,56 @@ void UI_DisplayMenu(void)
 #else
     {   // new menu layout .. experimental & unfinished
         const int menu_index = gMenuCursor;  // current selected menu item
-        i = 1;
+        const int menu_count = (int)gMenuListCount;
 
-        if (!gIsInSubMenu) {
-            while (i < 2)
-            {   // leading menu items - small text
-                const int k = menu_index + i - 2;
-                if (k < 0)
-                    UI_PrintStringSmallNormal(MenuList[gMenuListCount + k].name, 0, 0, i);  // wrap-a-round
-                else if (k >= 0 && k < (int)gMenuListCount)
-                    UI_PrintStringSmallNormal(MenuList[k].name, 0, 0, i);
-                i++;
-            }
+        if (menu_index >= 0 && menu_index < menu_count) 
+        {
+            if (!gIsInSubMenu) 
+            {
+                // leading menu items - small text
+                int prev_index = menu_index - 1;
+                if (prev_index < 0) {
+                    prev_index = menu_count - 1;
+                }
+                UI_PrintStringSmallNormal(MenuList[prev_index].name, 0, 0, 1);
 
-            // current menu item - keep big n fat
-            if (menu_index >= 0 && menu_index < (int)gMenuListCount)
+                // current menu item - keep big n fat
                 UI_PrintString(MenuList[menu_index].name, 0, 0, 2, 8);
-            i++;
 
-            while (i < 4)
-            {   // trailing menu item - small text
-                const int k = menu_index + i - 2;
-                if (k >= 0 && k < (int)gMenuListCount)
-                    UI_PrintStringSmallNormal(MenuList[k].name, 0, 0, 1 + i);
-                else if (k >= (int)gMenuListCount)
-                    UI_PrintStringSmallNormal(MenuList[gMenuListCount - k].name, 0, 0, 1 + i);  // wrap-a-round
-                i++;
+                // trailing menu item - small text
+                int next_index = menu_index + 1;
+                if (next_index >= menu_count) {
+                    next_index = 0;
+                }
+                UI_PrintStringSmallNormal(MenuList[next_index].name, 0, 0, 4);
+
+
+                // draw the menu index number/count
+    #ifndef ENABLE_FEAT_F4HWN
+                sprintf(String, "%2u.%u", 1 + menu_index, menu_count);
+                UI_PrintStringSmallNormal(String, 2, 0, 6);
+    #endif
+            }
+            else
+            {   
+                // current menu item
+//              strcat(String, ":");
+                UI_PrintString(MenuList[menu_index].name, 0, 0, 0, 8);
+//              UI_PrintStringSmallNormal(String, 0, 0, 0);
             }
 
-            // draw the menu index number/count
-#ifndef ENABLE_FEAT_F4HWN
-            sprintf(String, "%2u.%u", 1 + gMenuCursor, gMenuListCount);
-            UI_PrintStringSmallNormal(String, 2, 0, 6);
-#endif
+    #ifdef ENABLE_FEAT_F4HWN
+            sprintf(String, "%02u/%u", 1 + menu_index, menu_count);
+            UI_PrintStringSmallNormal(String, 6, 0, 6);
+    #endif
         }
-        else if (menu_index >= 0 && menu_index < (int)gMenuListCount)
-        {   // current menu item
-//          strcat(String, ":");
-            UI_PrintString(MenuList[menu_index].name, 0, 0, 0, 8);
-//          UI_PrintStringSmallNormal(String, 0, 0, 0);
-        }
-
-#ifdef ENABLE_FEAT_F4HWN
-        sprintf(String, "%02u/%u", 1 + gMenuCursor, gMenuListCount);
-        UI_PrintStringSmallNormal(String, 6, 0, 6);
-#endif
     }
 #endif
 
     // **************
 
-    memset(String, 0, sizeof(String));
-    memset(top_right_badge, 0, sizeof(top_right_badge));
+    String[0] = '\0';
+    top_right_badge[0] = '\0';
 
     bool already_printed = false;
 
@@ -1103,11 +1101,19 @@ void UI_DisplayMenu(void)
             break;
 #endif
         case MENU_UPCODE:
-            sprintf(String, "%.8s\n%.8s", gEeprom.DTMF_UP_CODE, gEeprom.DTMF_UP_CODE + 8);
+            if (gEeprom.DTMF_UP_CODE[8] != '\0' && gEeprom.DTMF_UP_CODE[8] != 0xFF) {
+                sprintf(String, "%.8s\n%.8s", gEeprom.DTMF_UP_CODE, gEeprom.DTMF_UP_CODE + 8);
+            } else {
+                sprintf(String, "%.8s", gEeprom.DTMF_UP_CODE);
+            }
             break;
 
         case MENU_DWCODE:
-            sprintf(String, "%.8s\n%.8s", gEeprom.DTMF_DOWN_CODE, gEeprom.DTMF_DOWN_CODE + 8);
+            if (gEeprom.DTMF_DOWN_CODE[8] != '\0' && gEeprom.DTMF_DOWN_CODE[8] != 0xFF) {
+                sprintf(String, "%.8s\n%.8s", gEeprom.DTMF_DOWN_CODE, gEeprom.DTMF_DOWN_CODE + 8);
+            } else {
+                sprintf(String, "%.8s", gEeprom.DTMF_DOWN_CODE);
+            }
             break;
 
 #ifdef ENABLE_DTMF_CALLING
@@ -1441,7 +1447,7 @@ void UI_DisplayMenu(void)
         unsigned int len   = strlen(String);
         bool         small = false;
 
-        if (len > 0)
+        if (String[0] != '\0')
         {
             // count number of lines
             for (i = 0; i < len; i++)
@@ -1508,30 +1514,25 @@ void UI_DisplayMenu(void)
     }
 #endif
 
-    if (m == MENU_R_CTCS ||
-        m == MENU_T_CTCS) {
-        const uint8_t approved_index =
-            (gSubMenuSelection > 0) ? DCS_GetCtcssApprovedIndex(gSubMenuSelection - 1) : 0xFF;
+    const bool is_ctcs = (m == MENU_R_CTCS || m == MENU_T_CTCS);
+    const bool is_dcs  = (m == MENU_R_DCS  || m == MENU_T_DCS);
 
-        if (gSubMenuSelection == 0)
-            sprintf(top_right_badge, "00/00");
-        else if (approved_index != 0xFF)
-            sprintf(top_right_badge, "%02u/%02u", (unsigned)gSubMenuSelection, (unsigned)approved_index + 1);
-        else
-            sprintf(top_right_badge, "%02u/--", (unsigned)gSubMenuSelection);
-    }
-    
-    if (m == MENU_R_DCS ||
-        m == MENU_T_DCS) {
-        const uint8_t approved_index =
-            (gSubMenuSelection > 0) ? DCS_GetDcsApprovedIndex(gSubMenuSelection - 1) : 0xFF;
+    if (is_ctcs || is_dcs) {
+        if (gSubMenuSelection == 0) {
+            strcpy(top_right_badge, is_ctcs ? "00/00" : "000/00");
+        } else {
+            const uint8_t approved_index = is_ctcs ? 
+                DCS_GetCtcssApprovedIndex(gSubMenuSelection - 1) : 
+                DCS_GetDcsApprovedIndex(gSubMenuSelection - 1);
+                
+            const uint8_t width = is_ctcs ? 2 : 3;
 
-        if (gSubMenuSelection == 0)
-            sprintf(top_right_badge, "000/00");
-        else if (approved_index != 0xFF)
-            sprintf(top_right_badge, "%03u/%02u", (unsigned)gSubMenuSelection, (unsigned)approved_index + 1);
-        else
-            sprintf(top_right_badge, "%03u/--", (unsigned)gSubMenuSelection);
+            if (approved_index != 0xFF) {
+                sprintf(top_right_badge, "%0*u/%02u", width, (unsigned)gSubMenuSelection, (unsigned)approved_index + 1);
+            } else {
+                sprintf(top_right_badge, "%0*u/--", width, (unsigned)gSubMenuSelection);
+            }
+        }
     }
 
 #ifdef ENABLE_DTMF_CALLING

--- a/App/ui/menu.h
+++ b/App/ui/menu.h
@@ -173,7 +173,7 @@ extern const char* const            gSubMenu_TXP[8];
 extern const char* const            gSubMenu_SFT_D[3];
 extern const char* const            gSubMenu_W_N[2];
 extern const char* const            gSubMenu_OFF_ON[2];
-extern const char* const            gSubMenu_NA[1];
+extern const char*                  gSubMenu_NA;
 extern const char* const            gSubMenu_TOT[11];
 extern const char* const            gSubMenu_RXMode[4];
 
@@ -232,13 +232,13 @@ extern const char* const            gSubMenu_SET_NAV[2];
     extern const char* const        gSubMenu_SCRAMBLER[11];
 #endif
 
-typedef struct __attribute__((packed)) {
+typedef struct /* __attribute__((packed)) */ {
     const char* name; 
     uint8_t     id;
 } t_sidefunction;
 
 extern const uint8_t         gSubMenu_SIDEFUNCTIONS_size;
-extern const t_sidefunction gSubMenu_SIDEFUNCTIONS[];
+extern const t_sidefunction  gSubMenu_SIDEFUNCTIONS[];
                          
 extern bool              gIsInSubMenu;
                          

--- a/App/ui/menu.h
+++ b/App/ui/menu.h
@@ -23,7 +23,7 @@
 #include "audio.h"     // VOICE_ID_t
 #include "settings.h"
 
-typedef struct {
+typedef struct __attribute__((packed)) {
     const char  name[7];    // menu display area only has room for 6 characters
     uint8_t     menu_id;
 } t_menu_item;
@@ -169,68 +169,74 @@ enum
 extern const uint8_t FIRST_HIDDEN_MENU_ITEM;
 extern const t_menu_item MenuList[];
 
-extern const char        gSubMenu_TXP[8][6];
-extern const char        gSubMenu_SFT_D[3][4];
-extern const char        gSubMenu_W_N[2][7];
-extern const char        gSubMenu_OFF_ON[2][4];
-extern const char        gSubMenu_NA[4];
-extern const char        gSubMenu_TOT[11][7];
-extern const char* const gSubMenu_RXMode[4];
+extern const char* const            gSubMenu_TXP[8];
+extern const char* const            gSubMenu_SFT_D[3];
+extern const char* const            gSubMenu_W_N[2];
+extern const char* const            gSubMenu_OFF_ON[2];
+extern const char* const            gSubMenu_NA[1];
+extern const char* const            gSubMenu_TOT[11];
+extern const char* const            gSubMenu_RXMode[4];
 
 #ifdef ENABLE_VOICE
-    extern const char    gSubMenu_VOICE[3][4];
+    extern const char* const        gSubMenu_VOICE[3];
 #endif
-extern const char* const gSubMenu_MDF[4];
+extern const char* const            gSubMenu_MDF[4];
 #ifdef ENABLE_ALARM
-    extern const char    gSubMenu_AL_MOD[2][5];
+    extern const char* const        gSubMenu_AL_MOD[2];
 #endif
 #ifdef ENABLE_DTMF_CALLING
-extern const char        gSubMenu_D_RSP[4][11];
+extern const char* const            gSubMenu_D_RSP[4];
 #endif
 
 #ifdef ENABLE_FEAT_F4HWN
-    extern const char    gSubMenu_SET_PWR[7][6];
-    extern const char    gSubMenu_SET_PTT[2][8];
-    extern const char    gSubMenu_SET_TOT[4][7];
-    extern const char    gSubMenu_SET_LCK[2][9];
-    extern const char    gSubMenu_SET_MET[2][8];
+    extern const char* const        gSubMenu_SET_PWR[7];
+    extern const char* const        gSubMenu_SET_PTT[2];
+    extern const char* const        gSubMenu_SET_TOT[4];
+    extern const char* const        gSubMenu_SET_LCK[2];
+    extern const char* const        gSubMenu_SET_MET[2];
     #ifdef ENABLE_FEAT_F4HWN_SCAN_FASTER
-        extern const char    gSubMenu_SET_SCN[2][7];
+        extern const char* const    gSubMenu_SET_SCN[2];
     #endif
     #ifdef ENABLE_FEAT_F4HWN_NARROWER
-        extern const char    gSubMenu_SET_NFM[2][9];
+        extern const char* const    gSubMenu_SET_NFM[2];
     #endif
     #ifdef ENABLE_FEAT_F4HWN_RESCUE_OPS
-        extern const char gSubMenu_SET_KEY[][9];
+        extern const char* const    gSubMenu_SET_KEY[5];
     #endif
     #ifdef ENABLE_FEAT_F4HWN_AUDIO
-        extern const char    gSubMenu_SET_AUD_FM[5][6];
-        extern const char    gSubMenu_SET_AUD_AM[3][6];
+        extern const char* const    gSubMenu_SET_AUD_FM[5];
+        extern const char* const    gSubMenu_SET_AUD_AM[3];
     #endif
 #endif
 
 extern const char* const gSubMenu_PTT_ID[5];
 #ifdef ENABLE_FEAT_F4HWN
     #ifdef ENABLE_FEAT_F4HWN_LOGO
-        extern const char        gSubMenu_PONMSG[6][8];
+        extern const char* const    gSubMenu_PONMSG[6];
     #else
-        extern const char        gSubMenu_PONMSG[5][8];
+        extern const char* const    gSubMenu_PONMSG[5];
     #endif
 #else
-    extern const char        gSubMenu_PONMSG[4][8];
+    extern const char* const        gSubMenu_PONMSG[4];
 #endif
-extern const char        gSubMenu_ROGER[3][6];
-extern const char        gSubMenu_RESET[2][4];
-extern const char* const gSubMenu_F_LOCK[F_LOCK_LEN];
-extern const char        gSubMenu_RX_TX[4][6];
-extern const char        gSubMenu_BAT_TXT[3][8];
-extern const char        gSubMenu_BATTYP[5][12];
+
+extern const char* const            gSubMenu_ROGER[3];
+extern const char* const            gSubMenu_RESET[2];
+extern const char* const            gSubMenu_F_LOCK[F_LOCK_LEN];
+extern const char* const            gSubMenu_RX_TX[4];
+extern const char* const            gSubMenu_BAT_TXT[3];
+extern const char* const            gSubMenu_BATTYP[5];
+extern const char* const            gSubMenu_SET_NAV[2];
 
 #ifndef ENABLE_FEAT_F4HWN
-    extern const char        gSubMenu_SCRAMBLER[11][7];
+    extern const char* const        gSubMenu_SCRAMBLER[11];
 #endif
 
-typedef struct {char* name; uint8_t id;} t_sidefunction;
+typedef struct __attribute__((packed)) {
+    const char* name; 
+    uint8_t     id;
+} t_sidefunction;
+
 extern const uint8_t         gSubMenu_SIDEFUNCTIONS_size;
 extern const t_sidefunction gSubMenu_SIDEFUNCTIONS[];
                          

--- a/App/ui/scanner.c
+++ b/App/ui/scanner.c
@@ -26,7 +26,7 @@
 
 void UI_DisplayScanner(void)
 {
-    char  String[16] = {0};
+    char  String[16];
     char *pPrintStr = String;
     bool bCentered;
     uint8_t Start;
@@ -53,7 +53,6 @@ void UI_DisplayScanner(void)
     }
 
     UI_PrintString(pPrintStr, 2, 0, 3, 8);
-    memset(String, 0, sizeof(String));
     if (gScannerSaveState == SCAN_SAVE_CHANNEL) {
         pPrintStr = "SAVE?";
         Start     = 0;
@@ -68,7 +67,9 @@ void UI_DisplayScanner(void)
             pPrintStr = String;
         } else if (gScanCssState < SCAN_CSS_STATE_FOUND) {
             strcpy(String, "SCAN");
-            memset(String + 4, '.', (gScanProgressIndicator & 7) + 1);
+            uint8_t dotCount = (gScanProgressIndicator & 7) + 1; 
+            memset(String + 4, '.', dotCount); 
+            String[4 + dotCount] = '\0'; 
             pPrintStr = String;
         } else if (gScanCssState == SCAN_CSS_STATE_FOUND) {
             pPrintStr = "SCAN CMP.";

--- a/App/ui/status.c
+++ b/App/ui/status.c
@@ -99,8 +99,8 @@ void UI_DisplayStatus()
 
                 if(gEeprom.SCAN_LIST_DEFAULT == MR_CHANNELS_LIST + 1)
                 {
-                    sprintf(str, gEeprom.SCAN_LIST_ENABLED ? "%s+" : "%s", "ALL");
-                    end = gEeprom.SCAN_LIST_ENABLED ? 18 : 14;
+                    strcpy(str, "ALL");
+                    end = 14;
                 }
                 else
                 {
@@ -108,13 +108,17 @@ void UI_DisplayStatus()
 
                     // Check if name is valid
                     if (!IsEmptyName(name, sizeof(gListName[0]))) {
-                        sprintf(str, "%.3s%s", name, gEeprom.SCAN_LIST_ENABLED ? "+" : "");
-                        end = gEeprom.SCAN_LIST_ENABLED ? 18 : 14;
-                    } 
-                    else {
-                        sprintf(str, "%02d%s", gEeprom.SCAN_LIST_DEFAULT, gEeprom.SCAN_LIST_ENABLED ? "+" : "");
-                        end = gEeprom.SCAN_LIST_ENABLED ? 14 : 10;
+                        sprintf(str, "%.3s", name);
+                        end = 14;
+                    } else {
+                        sprintf(str, "%02d", gEeprom.SCAN_LIST_DEFAULT);
+                        end = 10;
                     }
+                }
+
+                if (gEeprom.SCAN_LIST_ENABLED) {
+                    strcat(str, "+");
+                    end += 4;
                 }
 
                 GUI_DisplaySmallest(str, 2, 1, true, true);

--- a/App/ui/welcome.c
+++ b/App/ui/welcome.c
@@ -217,11 +217,6 @@ void UI_DisplayReleaseKeys(void)
 
 void UI_DisplayWelcome(void)
 {
-    char WelcomeString0[16];
-    char WelcomeString1[16];
-    char WelcomeString2[16];
-    char WelcomeString3[32];
-
     UI_StatusClear();
 
 #if defined(ENABLE_FEAT_F4HWN_CTR) || defined(ENABLE_FEAT_F4HWN_INV)
@@ -229,36 +224,33 @@ void UI_DisplayWelcome(void)
 #endif
     UI_DisplayClear();
 
-#ifdef ENABLE_FEAT_F4HWN_LOGO
-    if (gEeprom.POWER_ON_DISPLAY_MODE == POWER_ON_DISPLAY_MODE_LOGO) {
-        // Skip 8-byte header, then read 128x64 bitmap (1024 B):
-        // page 0 -> gStatusLine, pages 1..7 -> gFrameBuffer.
-        PY25Q16_ReadBuffer(LOGO_BITMAP_ADDR, gStatusLine, sizeof(gStatusLine));
-        PY25Q16_ReadBuffer(LOGO_BITMAP_ADDR + sizeof(gStatusLine), gFrameBuffer, sizeof(gFrameBuffer));
-        ST7565_BlitStatusLine();
-        ST7565_BlitFullScreen();
-        #ifdef ENABLE_FEAT_F4HWN_SCREENSHOT
-            SCREENSHOT_Update(true);
-        #endif
-        return;
-    }
-#endif
-
 #ifdef ENABLE_FEAT_F4HWN
     ST7565_BlitStatusLine();
     ST7565_BlitFullScreen();
 
     if (gEeprom.POWER_ON_DISPLAY_MODE == POWER_ON_DISPLAY_MODE_NONE || gEeprom.POWER_ON_DISPLAY_MODE == POWER_ON_DISPLAY_MODE_SOUND) {
         ST7565_FillScreen(0x00);
+        return;
     }
 #else
     if (gEeprom.POWER_ON_DISPLAY_MODE == POWER_ON_DISPLAY_MODE_NONE || gEeprom.POWER_ON_DISPLAY_MODE == POWER_ON_DISPLAY_MODE_FULL_SCREEN) {
         ST7565_FillScreen(0xFF);
+        return;
+    }
+#endif
+#ifdef ENABLE_FEAT_F4HWN_LOGO
+    else if (gEeprom.POWER_ON_DISPLAY_MODE == POWER_ON_DISPLAY_MODE_LOGO) {
+        // Skip 8-byte header, then read 128x64 bitmap (1024 B):
+        // page 0 -> gStatusLine, pages 1..7 -> gFrameBuffer.
+        PY25Q16_ReadBuffer(LOGO_BITMAP_ADDR, gStatusLine, sizeof(gStatusLine));
+        PY25Q16_ReadBuffer(LOGO_BITMAP_ADDR + sizeof(gStatusLine), gFrameBuffer, sizeof(gFrameBuffer));
     }
 #endif
     else {
-        memset(WelcomeString0, 0, sizeof(WelcomeString0));
-        memset(WelcomeString1, 0, sizeof(WelcomeString1));
+        char WelcomeString0[16];
+        char WelcomeString1[16];
+        char WelcomeString2[16];
+        char WelcomeString3[32];
 
         // 0x0EB0
         PY25Q16_ReadBuffer(0x00A0C8, WelcomeString0, 16);
@@ -346,12 +338,12 @@ void UI_DisplayWelcome(void)
 #else
         UI_PrintStringSmallNormal(Version, 0, 127, 6);
 #endif
-
-        //ST7565_BlitStatusLine();  // blank status line : I think it's useless
-        ST7565_BlitFullScreen();
-
-        #ifdef ENABLE_FEAT_F4HWN_SCREENSHOT
-            SCREENSHOT_Update(true);
-        #endif
     }
+
+    ST7565_BlitStatusLine();
+    ST7565_BlitFullScreen();
+
+    #ifdef ENABLE_FEAT_F4HWN_SCREENSHOT
+        SCREENSHOT_Update(true);
+    #endif
 }


### PR DESCRIPTION
**Hello.**

I’d like to present a code refactoring that will save 288 bytes. The changes mainly involve strings, but not exclusively.

I reduced the deletion of content in strings. Instead, I change the first character in the array to the terminator ``\0`` and, in some places, correct the omission of assigning ``\0`` at the end. Thanks to this, I significantly reduced memory usage, and the effect is the same.

In menu.c, I changed ``const char [][]`` to ``const char* const []``, which saved quite a few bytes. 

They say you learn your whole life. It’s true - I discovered, for example, that the ``sprintf`` function returns the length of the string. I found an interesting use for this property: in calculating how many digits are in a number. Instead of creating a new function:

```c
static uint8_t ScanProgress_DecimalDigits(uint32_t value)
{
    uint8_t digits = 1;

    while (value >= 10u) {
        value /= 10u;
        digits++;
    }

    return digits;
}
```

You can use sprintf, which returns exactly the same result:

```c
static inline uint8_t ScanProgress_DecimalDigits(uint32_t value)
{
    return sprintf(NULL, "%u", value);
}
```

There are also things like: fixing the display of UPCode and DWCode in the center, refactoring AirCopy (replacing percentage calculations with the DDA/Bresenham algorithm), refactoring the display of menu items, and more...

---

I hope you like it, and I look forward to your feedback.