### PR TITLE
Prevent screensaver during M-SCAN; Code refactoring (20 B)

### DIFF
--- a/App/app/app.c
+++ b/App/app/app.c
@@ -250,7 +250,7 @@ static bool ScreenSaverCanDisplay(void)
         FUNCTION_IsRx() ||
         gPttIsPressed
 #ifdef ENABLE_FMRADIO
-        || gFM_ScanState != FM_SCAN_OFF
+        || (gFM_ScanState != FM_SCAN_OFF && !gFM_FoundFrequency)
 #endif
 #ifdef ENABLE_FEAT_F4HWN_BEAM
         || gBeamActive

--- a/App/app/fm.c
+++ b/App/app/fm.c
@@ -94,6 +94,11 @@ int FM_ConfigureChannelState(void)
     return 0;
 }
 
+void FM_SetFrequency(void)
+{
+    BK1080_SetFrequency(gEeprom.FM_FrequencyPlaying, gEeprom.FM_Band/*, gEeprom.FM_Space*/);
+}
+
 void FM_TurnOff(void)
 {
     gFmRadioMode              = false;
@@ -163,11 +168,10 @@ void FM_Tune(uint16_t Frequency, int8_t Step, bool bFlag)
 
     gFM_ScanState = Step;
 
-    BK1080_SetFrequency(gEeprom.FM_FrequencyPlaying, gEeprom.FM_Band/*, gEeprom.FM_Space*/);
+    FM_SetFrequency();
 }
 
 void FM_AudioPathOn(void) {
-    BACKLIGHT_TurnOn();
     AUDIO_AudioPathOn();
     gEnableSpeaker = true;
 }
@@ -182,13 +186,14 @@ void FM_PlayAndUpdate(void)
     }
 
     FM_ConfigureChannelState();
-    BK1080_SetFrequency(gEeprom.FM_FrequencyPlaying, gEeprom.FM_Band/*, gEeprom.FM_Space*/);
+    FM_SetFrequency();
     SETTINGS_SaveFM();
 
     gFmPlayCountdown_10ms = 0;
     gScheduleFM           = false;
     gAskToSave            = false;
 
+    BACKLIGHT_TurnOn();
     FM_AudioPathOn();
 }
 
@@ -291,7 +296,7 @@ static void Key_DIGITS(KEY_Code_t Key, uint8_t state)
                 gAnotherVoiceID = (VOICE_ID_t)Key;
 #endif
                 gEeprom.FM_FrequencyPlaying = gEeprom.FM_SelectedFrequency;
-                BK1080_SetFrequency(gEeprom.FM_FrequencyPlaying, gEeprom.FM_Band/*, gEeprom.FM_Space*/);
+                FM_SetFrequency();
                 gRequestSaveFM = true;
                 return;
             }
@@ -311,7 +316,7 @@ static void Key_DIGITS(KEY_Code_t Key, uint8_t state)
 #endif
                     gEeprom.FM_SelectedChannel = Channel;
                     gEeprom.FM_FrequencyPlaying = gFM_Channels[Channel];
-                    BK1080_SetFrequency(gEeprom.FM_FrequencyPlaying, gEeprom.FM_Band/*, gEeprom.FM_Space*/);
+                    FM_SetFrequency();
                     gRequestSaveFM = true;
                     return;
                 }
@@ -366,7 +371,7 @@ static void Key_FUNC(KEY_Code_t Key, uint8_t state)
                 gEeprom.FM_IsMrMode = !gEeprom.FM_IsMrMode;
 
                 if (!FM_ConfigureChannelState()) {
-                    BK1080_SetFrequency(gEeprom.FM_FrequencyPlaying, gEeprom.FM_Band/*, gEeprom.FM_Space*/);
+                    FM_SetFrequency();
                     gRequestSaveFM = true;
                 }
                 else
@@ -480,7 +485,7 @@ static void Key_MENU(uint8_t state)
                 gFM_Channels[gEeprom.FM_SelectedChannel] = 0xFFFF;
 
                 FM_ConfigureChannelState();
-                BK1080_SetFrequency(gEeprom.FM_FrequencyPlaying, gEeprom.FM_Band/*, gEeprom.FM_Space*/);
+                FM_SetFrequency();
 
                 gRequestSaveFM = true;
             }
@@ -558,7 +563,7 @@ static void Key_UP_DOWN(uint8_t state, int8_t Step)
     gRequestSaveFM = true;
 
 Bail:
-    BK1080_SetFrequency(gEeprom.FM_FrequencyPlaying, gEeprom.FM_Band/*, gEeprom.FM_Space*/);
+    FM_SetFrequency();
 
     gRequestDisplayScreen = DISPLAY_FM;
 }
@@ -612,19 +617,18 @@ void FM_Play(void)
             if (!gEeprom.FM_IsMrMode)
                 gEeprom.FM_SelectedFrequency = gEeprom.FM_FrequencyPlaying;
 
+            BACKLIGHT_TurnOn();
             FM_AudioPathOn();
 
-            GUI_SelectNextDisplay(DISPLAY_FM);
-            return;
+            goto Display;
         }
 
         if (gFM_ChannelPosition < FM_CHANNELS_MAX)
             gFM_Channels[gFM_ChannelPosition++] = gEeprom.FM_FrequencyPlaying;
-
-        if (gFM_ChannelPosition >= FM_CHANNELS_MAX) {
+        else {
             FM_PlayAndUpdate();
-            GUI_SelectNextDisplay(DISPLAY_FM);
-            return;
+
+            goto Display;
         }
     }
 
@@ -633,6 +637,7 @@ void FM_Play(void)
     else
         FM_Tune(gEeprom.FM_FrequencyPlaying, gFM_ScanState, false);
 
+Display:
     GUI_SelectNextDisplay(DISPLAY_FM);
 }
 

--- a/App/app/fm.c
+++ b/App/app/fm.c
@@ -625,7 +625,8 @@ void FM_Play(void)
 
         if (gFM_ChannelPosition < FM_CHANNELS_MAX)
             gFM_Channels[gFM_ChannelPosition++] = gEeprom.FM_FrequencyPlaying;
-        else {
+        
+        if (gFM_ChannelPosition >= FM_CHANNELS_MAX) {
             FM_PlayAndUpdate();
 
             goto Display;

--- a/App/helper/boot.c
+++ b/App/helper/boot.c
@@ -73,12 +73,14 @@ BOOT_Mode_t BOOT_GetMode(void)
 
 void BOOT_ProcessMode(BOOT_Mode_t Mode)
 {
+    GUI_DisplayType_t display = DISPLAY_MAIN;
+
     if (Mode == BOOT_MODE_F_LOCK)
     {
         #ifdef ENABLE_FEAT_F4HWN_RESUME_STATE
             gEeprom.CURRENT_STATE = 0; // Don't resume is active...
         #endif 
-        GUI_SelectNextDisplay(DISPLAY_MENU);
+        display = DISPLAY_MENU;
     }
     #ifdef ENABLE_AIRCOPY
         else
@@ -119,11 +121,9 @@ void BOOT_ProcessMode(BOOT_Mode_t Mode)
                 gEeprom.CURRENT_STATE = 0; // Don't resume is active...
             #endif 
 
-            GUI_SelectNextDisplay(DISPLAY_AIRCOPY);
+            display = DISPLAY_AIRCOPY;
         }
     #endif
-    else
-    {
-        GUI_SelectNextDisplay(DISPLAY_MAIN);
-    }
+
+    GUI_SelectNextDisplay(display);
 }


### PR DESCRIPTION
**Hello.**

I’d like to share the results I’ve achieved after some time. I’ve finally managed to solve the problem with the screensaver appearing during M-SCAN on FM radio. Now, during scanning, when the frequency is changing, the screensaver doesn’t appear; it appears when scanning is paused (a radio station has been found). I’ve also completely (I think) fixed the screensaver appearing when the backlight is on in the FM radio.

By the way, I did a tiny bit of refactoring that saved 20 bytes of code. I hope you like it.