### PR TITLE
Code refactoring (104 B)

### DIFF
--- a/App/app/dtmf.c
+++ b/App/app/dtmf.c
@@ -474,7 +474,7 @@ void DTMF_Reply(void)
     if (pString == NULL)
         return;
 
-    Delay = (gEeprom.DTMF_PRELOAD_TIME < 200) ? 200 : gEeprom.DTMF_PRELOAD_TIME;
+    Delay = MAX(gEeprom.DTMF_PRELOAD_TIME, 200);
 
     if (gEeprom.DTMF_SIDE_TONE)
     {   // the user will also hear the transmitted tones

--- a/App/radio.c
+++ b/App/radio.c
@@ -544,14 +544,14 @@ void RADIO_ConfigureSquelchAndOutputPower(VFO_Info_t *pInfo)
         if (glitch_close == glitch_open && glitch_close <= 253)
             glitch_close += 2;
 
-        pInfo->SquelchOpenRSSIThresh    = (rssi_open    > 255) ? 255 : rssi_open;
-        pInfo->SquelchCloseRSSIThresh   = (rssi_close   > 255) ? 255 : rssi_close;
-        pInfo->SquelchOpenGlitchThresh  = (glitch_open  > 255) ? 255 : glitch_open;
-        pInfo->SquelchCloseGlitchThresh = (glitch_close > 255) ? 255 : glitch_close;
+        pInfo->SquelchOpenRSSIThresh    = MIN(rssi_open,    255);
+        pInfo->SquelchCloseRSSIThresh   = MIN(rssi_close,   255);
+        pInfo->SquelchOpenGlitchThresh  = MIN(glitch_open,  255);
+        pInfo->SquelchCloseGlitchThresh = MIN(glitch_close, 255);
 #endif
 
-        pInfo->SquelchOpenNoiseThresh   = (noise_open   > 127) ? 127 : noise_open;
-        pInfo->SquelchCloseNoiseThresh  = (noise_close  > 127) ? 127 : noise_close;
+        pInfo->SquelchOpenNoiseThresh   = MIN(noise_open,   127);
+        pInfo->SquelchCloseNoiseThresh  = MIN(noise_close,  127);
     }
 
     // *******************************

--- a/App/ui/helper.c
+++ b/App/ui/helper.c
@@ -325,6 +325,23 @@ static void sort(int16_t *a, int16_t *b)
       }
     }
 
+    void GUI_DisplaySmallestInverse(const char *pString, uint8_t x, uint8_t Line,
+                                bool statusbar, bool fill, uint8_t end)
+    {
+        // First draw the string normally
+        GUI_DisplaySmallest(pString, x, (Line * 8) + 1, statusbar, fill);
+
+        // Now invert the framebuffer/statusline bits for the rendered area
+        uint8_t start = (x - 2);
+        uint8_t *buffer = statusbar ? gStatusLine : gFrameBuffer[Line];
+
+        buffer[start] ^= 0x3E;
+        for (uint8_t i = start + 1; i < end; i++) {
+            buffer[i] ^= 0x7F;
+        }
+        buffer[end] ^= 0x3E;
+    }
+
     void UI_DisplayUnlockKeyboard(uint8_t shift) {
         if (gEeprom.KEY_LOCK && gKeypadLocked > 0)
         {   // tell user how to unlock the keyboard

--- a/App/ui/helper.h
+++ b/App/ui/helper.h
@@ -38,6 +38,7 @@ void UI_DrawPixelBuffer(uint8_t (*buffer)[128], uint8_t x, uint8_t y, bool black
     void PutPixel(uint8_t x, uint8_t y, bool fill);
     void PutPixelStatus(uint8_t x, uint8_t y, bool fill);
     void GUI_DisplaySmallest(const char *pString, uint8_t x, uint8_t y, bool statusbar, bool fill);
+    void GUI_DisplaySmallestInverse(const char *pString, uint8_t x, uint8_t Line, bool statusbar, bool fill, uint8_t endX);
     void UI_DisplayUnlockKeyboard(uint8_t shift);
     bool IsEmptyName(const char *name, uint8_t len);
 #endif

--- a/App/ui/main.c
+++ b/App/ui/main.c
@@ -287,8 +287,7 @@ static void ScanProgress_DrawGaugeLine(uint8_t line, uint32_t current_index, uin
         current_index = total;
 
     head_col = (total <= 1) ? (fill_cols - 1) : ((current_index - 1) * (fill_cols - 1)) / (total - 1);
-    if (head_col >= fill_cols)
-        head_col = fill_cols - 1;
+    head_col = MIN(head_col, fill_cols - 1);
 
     gFrameBuffer[line][gauge_left] = 0x0c;
     gFrameBuffer[line][gauge_left + 1] = 0x12;
@@ -1613,6 +1612,9 @@ void UI_DisplayMain(void)
                     xStart = 117;
                 }
 
+#ifdef ENABLE_FEAT_F4HWN
+                GUI_DisplaySmallestInverse(displayStr, xStart + 2, line, false, true, 127);  
+#else
                 GUI_DisplaySmallest(displayStr, xStart + 2, line == 0 ? 1 : 33, false, true);
 
                 gFrameBuffer[line][xStart] ^= 0x3E;
@@ -1620,6 +1622,7 @@ void UI_DisplayMain(void)
                     gFrameBuffer[line][x] ^= 0x7F;
                 }
                 gFrameBuffer[line][127] ^= 0x3E;
+#endif
 
                 #ifdef ENABLE_FEAT_F4HWN_RESCUE_OPS
                 {
@@ -2237,13 +2240,18 @@ void UI_DisplayMain(void)
     if (isMainOnly() && !gDTMF_InputMode)
     {
         sprintf(String, "VFO %s", activeTxVFO ? "B" : "A");
-        GUI_DisplaySmallest(String, 107, 50, false, true);
+
+#ifdef ENABLE_FEAT_F4HWN
+        GUI_DisplaySmallestInverse(String, 107, 6, false, true, 127);
+#else
+        GUI_DisplaySmallest(String, 107, 49, false, true);
 
         gFrameBuffer[6][105] ^= 0x7C;
         for (uint8_t x = 106; x < 127; x++) {
             gFrameBuffer[6][x] ^= 0xFE;
         }
         gFrameBuffer[6][127] ^= 0x7C;
+#endif
 
         /*
         UI_PrintStringSmallBold(String, 92, 0, 6);

--- a/App/ui/status.c
+++ b/App/ui/status.c
@@ -44,8 +44,6 @@ static void convertTime(uint8_t *line, uint8_t type)
     uint8_t m = t / 60;
     uint8_t s = t - (m * 60); // Replace modulo with subtraction for efficiency
 
-    gStatusLine[0] = gStatusLine[7] = gStatusLine[14] = 0x00; // Quick fix on display (on scanning I, II, etc.)
-
     char str[6];
     sprintf(str, "%02u:%02u", m, s);
     UI_PrintStringSmallBufferNormal(str, line);
@@ -64,8 +62,17 @@ void UI_DisplayStatus()
 
     uint8_t     *line = gStatusLine;
     unsigned int x    = 0;
+    unsigned int x1   = 0;
 
     char str[8] = "";
+
+#ifdef ENABLE_FEAT_F4HWN_RX_TX_TIMER
+    bool isTransmit = gCurrentFunction == FUNCTION_TRANSMIT;
+    if (gSetting_set_tmr && (isTransmit || FUNCTION_IsRx())) {
+        convertTime(line, !isTransmit);
+        x += 39;
+    } else {
+#endif
 
 #ifdef ENABLE_NOAA
     // NOAA indicator
@@ -85,7 +92,7 @@ void UI_DisplayStatus()
     x += 8;
 #endif
 
-    unsigned int x1 = x;
+    x1 = x;
 
 #ifdef ENABLE_DTMF_CALLING
     if (gSetting_KILLED) {
@@ -97,7 +104,6 @@ void UI_DisplayStatus()
     { // SCAN indicator
         if (gScanStateDir != SCAN_OFF || SCANNER_IsScanning()) {
             if (IS_MR_CHANNEL(gNextMrChannel) && !SCANNER_IsScanning()) { // channel mode
-
                 uint8_t end = 0;
 
                 if(gEeprom.SCAN_LIST_DEFAULT == MR_CHANNELS_LIST + 1)
@@ -124,6 +130,9 @@ void UI_DisplayStatus()
                     end += 4;
                 }
 
+#ifdef ENABLE_FEAT_F4HWN
+                GUI_DisplaySmallestInverse(str, 2, 0, true, true, end);
+#else
                 GUI_DisplaySmallest(str, 2, 1, true, true);
 
                 gStatusLine[0] ^= 0x3E;
@@ -132,6 +141,7 @@ void UI_DisplayStatus()
                     gStatusLine[x] ^= 0x7F;
                 }
                 gStatusLine[end] ^= 0x3E;
+#endif
             }
             else {  // frequency mode
                 memcpy(line + x + 1, gFontS, sizeof(gFontS));
@@ -161,53 +171,48 @@ void UI_DisplayStatus()
         #endif
 
         if(!SCANNER_IsScanning()) {
-        #ifdef ENABLE_FEAT_F4HWN_RX_TX_TIMER
-            bool isTransmit = gCurrentFunction == FUNCTION_TRANSMIT;
-            if (gSetting_set_tmr && (isTransmit || FUNCTION_IsRx())) {
-                convertTime(line, !isTransmit);
-            }
-            else
-        #endif
-            {
-                if(!gAirCopyBootMode) {
-                    const void *src = NULL;    // Pointer to the font/bitmap to copy
-                    size_t sSize = 0;          // Size of the font/bitmap
-                    uint8_t sOff = 2;          // Offset relative to the reference position
+            if(!gAirCopyBootMode) {
+                const void *src = NULL;    // Pointer to the font/bitmap to copy
+                size_t sSize = 0;          // Size of the font/bitmap
+                uint8_t sOff = 2;          // Offset relative to the reference position
 
-                    #ifdef ENABLE_FEAT_F4HWN_RESCUE_OPS
-                        if (gEeprom.MENU_LOCK) {
-                            src = gFontRO;
-                            sSize = sizeof(gFontRO);
-                        } else 
-                    #endif
-                    {
-                        uint8_t xb = (gEeprom.CROSS_BAND_RX_TX != CROSS_BAND_OFF);
+                #ifdef ENABLE_FEAT_F4HWN_RESCUE_OPS
+                    if (gEeprom.MENU_LOCK) {
+                        src = gFontRO;
+                        sSize = sizeof(gFontRO);
+                    } else 
+                #endif
+                {
+                    uint8_t xb = (gEeprom.CROSS_BAND_RX_TX != CROSS_BAND_OFF);
 
-                        if (gEeprom.DUAL_WATCH != DUAL_WATCH_OFF) {
-                            if (gDualWatchActive) { // DWR - dual watch + respond
-                                src = gFontDWR;
-                                sOff = xb ? 2 : 0;
-                                sSize = sizeof(gFontDWR) - (xb ? 5 : 0);
-                            } else {
-                                src = gFontHold;
-                                sOff = 3;
-                                sSize = sizeof(gFontHold);
-                            }
+                    if (gEeprom.DUAL_WATCH != DUAL_WATCH_OFF) {
+                        if (gDualWatchActive) { // DWR - dual watch + respond
+                            src = gFontDWR;
+                            sOff = xb ? 2 : 0;
+                            sSize = sizeof(gFontDWR) - (xb ? 5 : 0);
                         } else {
-                            src   = xb ? gFontXB         : gFontMO;          // XB - crossband
-                            sSize = xb ? sizeof(gFontXB) : sizeof(gFontMO);  // MO - main only
+                            src = gFontHold;
+                            sOff = 3;
+                            sSize = sizeof(gFontHold);
                         }
+                    } else {
+                        src   = xb ? gFontXB         : gFontMO;          // XB - crossband
+                        sSize = xb ? sizeof(gFontXB) : sizeof(gFontMO);  // MO - main only
                     }
+                }
 
-                    // Perform the memcpy if a source was selected
-                    if (src) {
-                        memcpy(line + x + sOff, src, sSize);
-                    }
+                // Perform the memcpy if a source was selected
+                if (src) {
+                    memcpy(line + x + sOff, src, sSize);
                 }
             }
         }
         x += sizeof(gFontDWR) + 3;
     #endif
+
+#ifdef ENABLE_FEAT_F4HWN_RX_TX_TIMER
+    }
+#endif
 
 #ifdef ENABLE_VOX
     // VOX indicator
@@ -284,7 +289,7 @@ void UI_DisplayStatus()
             break;
 
         case 1:    // voltage
-            const uint16_t voltage = (gBatteryVoltageAverage <= 999) ? gBatteryVoltageAverage : 999; // limit to 9.99V
+            const uint16_t voltage = MIN(gBatteryVoltageAverage, 999); // limit to 9.99V
             sprintf(str, "%u.%02u", voltage / 100, voltage % 100);
             break;
 


### PR DESCRIPTION
**Hello.**

I’m presenting a code refactoring that saves 104 bytes. The changes mainly involve displaying the smallest text in inverted mode, displaying the timer during RX/TX, and using the ``MIN``/``MAX`` macro in a few places.

A minor side effect is that the text “``VFO A``/``VFO B``” is displayed one pixel higher. This is because the new function ``GUI_DisplaySmallestInverse()`` is based on lines rather than the y-coordinate (to save code). In my opinion, it actually looks better this way, as it aligns vertically with the text next to it.

I hope you like it, and I look forward to your feedback.