### PR TITLE
Dock: put the radio on a demodulator, and stop tunes forcing FM (F7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,8 @@ k5_eeprom.raw
 __pycache__/
 
 .DS_Store
-AGENTS.md
+
+# NOTE: upstream ignores AGENTS.md (agent instructions were meant to stay local).
+# This fork tracks it deliberately - it carries the byte-compatibility contract with
+# radio-server and the BENCH.md placeholder rule, which are not optional local notes.
+# Keep this divergence when rebasing on a new F4HWN release.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,134 @@
+# AGENTS.md
+
+Guidance for AI agents and developers working in this repository. For the human-facing documentation,
+start at [README.md](README.md); for the protocol, [PROTOCOL.md](PROTOCOL.md).
+
+## Overview
+
+This is **F4HWN with one addition: a dock control mode** — a serial protocol that lets a host computer
+read and write the radio's BK4819 registers, take the radio over, and hand it a whole channel to tune
+itself to. Everything else is upstream's.
+
+- **Radio:** UV-K1 / UV-K5 **V3**, the **PY32F071** MCU. Not a classic UV-K5 (DP32G030).
+- **Base:** [`armel/uv-k1-k5v3-firmware-custom`](https://github.com/armel/uv-k1-k5v3-firmware-custom)
+  tag `v5.7.0` = commit `3bd3ebb`, Apache-2.0. The `Fusion` preset is the one that matters.
+- **Consumer:** [radio-server](https://github.com/kbennett2000/radio-server), though the protocol is
+  documented and has no dependency on it.
+
+C, CMake, ARM GNU Toolchain 13.3, built in Docker.
+
+## Build
+
+```sh
+./compile-with-docker.sh Fusion       # -> build/Fusion/f4hwn.fusion.bin
+```
+
+**The script passes `docker run -it`, so it fails without a TTY.** Headless, run it directly:
+
+```sh
+docker build -t uvk1-uvk5v3 .
+docker run --rm -u $(id -u):$(id -g) -v "$PWD":/src -w /src uvk1-uvk5v3 \
+  bash -c "cmake --preset Fusion && cmake --build --preset Fusion -j"
+```
+
+The dock mode is behind `ENABLE_DOCK`, enabled in the Fusion preset. Flash region is 118 KB and the
+build sits around 87% of it — check the linker's report before adding anything large.
+
+**Builds are reproducible up to a timestamp.** The firmware embeds its build time, so two builds of
+the same commit differ in ~5 bytes. Compare with `cmp -l` before concluding a tree differs.
+
+## Test
+
+```sh
+make -C tests/host run       # 66 checks; needs only a C compiler, no Docker, no hardware
+```
+
+`App/app/dock.c` is deliberately **pure C with no firmware or hardware includes** — all hardware sits
+behind a caller-supplied `dock_hal_t`. Keep it that way: it is what lets the protocol core be tested
+on a development machine, and what lets third parties lift it as a reference decoder.
+
+**Every protocol change needs a host test, including a byte-exact frame** where the wire changes.
+`tests/host/test_dock.c` holds golden vectors that are the oracle for anyone implementing a client.
+
+## The contract that governs everything here
+
+**The dock wire protocol must stay byte-compatible with
+[radio-server](https://github.com/kbennett2000/radio-server)'s `radio_server/backends/uvk5/frames.py`.**
+That is not a preference — it is the reason this port was done as a port rather than a redesign, and
+it is what keeps one host program working against both this firmware and nicsure's classic-UV-K5 Dock.
+
+- A change that alters bytes on the wire is a **cross-repo change**. Nothing checks the two
+  implementations stay in step (radio-server ADR 0148 records this as open), so it is on you.
+- New commands are additive and must be **ignored silently by older firmware** — that is how a host
+  detects firmware level.
+- `PROTOCOL.md` is the spec. If you change the wire, change it, and re-verify its golden vectors
+  against **both** implementations.
+
+## Where the reasoning lives
+
+**Mostly in the other repository.** Only `adr/0001-dock-force-tx.md` (F5) is local. The rest —
+why the fork exists, the protocol port, the RX audio fix, the set-VFO decision — are radio-server
+ADRs **0118, 0119, 0120, 0126, 0140, 0142** and its `docs/HANDOFF.md`. Read them before changing the
+dock code; several document failure modes that took a bench cycle each to find.
+
+## Firmware levels
+
+Releases are tagged `radio-server-fN-v5.7.0`; branches `fN-*` are kept for history. `main` is the tip.
+
+| Level | Adds | Symptom without it |
+|---|---|---|
+| **F2** | dock mode: `0x0850`/`0x0851`/`0x0870`/`0x0871` | commands silently ignored |
+| **F3** | forces the RX audio path alive on `0x0870` | connects, receives **silence**, all registers read back correct |
+| **F5** | engages the PA on the key-up edge | keys cleanly, **radiates nothing usable** |
+| **F6** | `0x0873`/`0x0874` set-VFO | tuning does not survive `0x0871`; no power control |
+
+None of F3 or F5's absence looks like a fault from the host — the radio reports success and does
+nothing. When something is silent, check the level first.
+
+## Guardrails (do not violate)
+
+1. **Do not fill in `BENCH.md`'s `⚠ CONFIRM AT BENCH` placeholders from inference.** Five numbered
+   items (DFU entry, the FTDI cable, the tab-conflict gotcha, the calibration dump) plus the
+   resume-RX behaviour at `:111` are marked because **nobody has confirmed them on the radio**. A
+   plausible guess written as fact is worse than the placeholder — this is firmware that can brick a
+   radio. Replace a marker only with a bench result.
+2. **Validate before acting; refuse, never clamp.** Every `0x0873` field is checked before anything is
+   written, and a bad one is refused with a status code. This is load-bearing twice over: a silently
+   moved channel can transmit on somebody else's repeater, and the refusal-before-action property is
+   what makes an empty `0x0873` a **safe firmware-level probe** for hosts. `FREQUENCY_GetBand()`
+   *clamps*, which is why `Dock_FreqInBand()` re-checks.
+3. **Any non-zero reply status blanks the frequency fields** — enforced in `dock.c`, not left to each
+   HAL, so no binding can publish a channel the radio is not on.
+4. **Keep `dock.c` free of firmware includes.** Hardware goes behind `dock_hal_t`.
+5. **Touch as little of upstream as possible.** Thirteen files differ from `3bd3ebb`; four of them are
+   upstream files that gained a dispatch case, a HAL binding and a build flag. Nothing in the radio's
+   own operation changes until a host sends `0x0870`. Keep it that way — it is what makes rebasing on
+   a new F4HWN release tractable.
+6. **Licence hygiene.** Apache-2.0. The dock port derives from nicsure's Apache-2.0 `quansheng-dock-fw`;
+   its GPL-2.0 Windows client is read as a specification and **never** copied. Record derivations in
+   [NOTICE](NOTICE).
+
+## `.gitignore` will silently swallow your documentation
+
+Upstream's `.gitignore` ignores **`/docs`**, **`.claude`** and **`.agents`**, and it used to ignore
+**`AGENTS.md`** (this fork un-ignores that one deliberately — keep the divergence when rebasing).
+
+`git add -A` skips an ignored path **without a word**, so a doc written into `docs/` commits as
+nothing, the push succeeds, and you find out when somebody follows a link to a file that was never
+there. That is exactly how the first version of this file failed to land.
+
+**Put documentation at the repo root** (`PROTOCOL.md`, `BENCH.md`, `AGENTS.md`), and after any commit
+that adds a file, check it is actually in the commit:
+
+```sh
+git show --stat --name-only HEAD
+```
+
+## Layout
+
+- `App/app/dock.c`, `App/app/dock.h` — **ours**: the pure protocol core.
+- `App/app/uart.c` — upstream, plus our dispatch cases and `Dock_*` HAL glue.
+- `App/CMakeLists.txt`, `CMakePresets.json` — upstream, plus `ENABLE_DOCK`.
+- `tests/host/` — **ours**: the host harness.
+- `PROTOCOL.md`, `BENCH.md`, `NOTICE`, `adr/` — **ours**.
+- Everything else is F4HWN's. Leave it alone unless you are rebasing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ the same commit differ in ~5 bytes. Compare with `cmp -l` before concluding a tr
 ## Test
 
 ```sh
-make -C tests/host run       # 66 checks; needs only a C compiler, no Docker, no hardware
+make -C tests/host run       # 98 checks; needs only a C compiler, no Docker, no hardware
 ```
 
 `App/app/dock.c` is deliberately **pure C with no firmware or hardware includes** — all hardware sits
@@ -81,17 +81,19 @@ Releases are tagged `radio-server-fN-v5.7.0`; branches `fN-*` are kept for histo
 | **F3** | forces the RX audio path alive on `0x0870` | connects, receives **silence**, all registers read back correct |
 | **F5** | engages the PA on the key-up edge | keys cleanly, **radiates nothing usable** |
 | **F6** | `0x0873`/`0x0874` set-VFO | tuning does not survive `0x0871`; no power control |
+| **F7** | `0x0877`/`0x0878` set-modulation; `0x0873` stops forcing FM | the radio is FM-only — no way to receive AM |
 
 None of F3 or F5's absence looks like a fault from the host — the radio reports success and does
 nothing. When something is silent, check the level first.
 
 ## Guardrails (do not violate)
 
-1. **Do not fill in `BENCH.md`'s `⚠ CONFIRM AT BENCH` placeholders from inference.** Five numbered
-   items (DFU entry, the FTDI cable, the tab-conflict gotcha, the calibration dump) plus the
-   resume-RX behaviour at `:111` are marked because **nobody has confirmed them on the radio**. A
-   plausible guess written as fact is worse than the placeholder — this is firmware that can brick a
-   radio. Replace a marker only with a bench result.
+1. **Do not fill in `BENCH.md`'s `⚠ CONFIRM AT BENCH` placeholders from inference.** Every one of
+   them — flashing (DFU entry, the FTDI cable, the tab-conflict gotcha, the calibration dump), the
+   resume-RX behaviour after `0x0871`, and F7's AM receive and PTT-refusal items — is marked because
+   **nobody has confirmed it on the radio**. A plausible guess written as fact is worse than the
+   placeholder — this is firmware that can brick a radio. Replace a marker only with a bench result.
+   Do not restate the count either: it was wrong in both files before F7 added to it.
 2. **Validate before acting; refuse, never clamp.** Every `0x0873` field is checked before anything is
    written, and a bad one is refused with a status code. This is load-bearing twice over: a silently
    moved channel can transmit on somebody else's repeater, and the refusal-before-action property is

--- a/App/CMakeLists.txt
+++ b/App/CMakeLists.txt
@@ -233,6 +233,15 @@ endif()
 enable_feature(ENABLE_AGC_SHOW_DATA)
 enable_feature(ENABLE_UART_RW_BK_REGS)
 
+# ---- radio-server dock control mode ----
+# Pure protocol core in app/dock.c, wired to BK4819/UART in app/uart.c.
+enable_feature(ENABLE_DOCK
+    app/dock.c
+)
+if(ENABLE_DOCK AND NOT ENABLE_UART)
+    message(FATAL_ERROR "ENABLE_DOCK requires ENABLE_UART (the dock rides the UART command dispatch).")
+endif()
+
 # ---- COMPILER/LINKER OPTIONS ----
 
 enable_feature(ENABLE_SWD)

--- a/App/app/dock.c
+++ b/App/app/dock.c
@@ -71,12 +71,18 @@ void dock_init(dock_ctx_t *ctx, const dock_hal_t *hal)
     ctx->hal          = hal;
     ctx->full_control = false;
     ctx->tx_on        = false;
+    /* A CONSTANT, deliberately — never a read of the radio's current modulation.
+     * Seeding from the radio is the "adopt whatever state you find" fault ADR 0132
+     * removed, and it would hand a repeater channel whatever the front panel was
+     * last left on. FM so a host that never sends 0x0877 sees F6 behaviour exactly. */
+    ctx->modulation   = DOCK_MOD_FM;
     ctx->len          = 0;
 }
 
-/* Longest parameter block this core replies with (0x0874's 12; 0x0951 uses 4).
- * Named rather than implied by the largest caller, so adding a reply that does
- * not fit is a compile-time size check instead of a stack overrun. */
+/* Longest parameter block this core replies with (0x0874's 12; 0x0878 uses 4, and
+ * so does 0x0951). Named rather than implied by the largest caller, because
+ * dock_send_payload SILENTLY SENDS NOTHING for a longer block — so a new reply that
+ * does not fit would look exactly like a firmware that never got the command. */
 #define DOCK_REPLY_MAX_PARAMS 12u
 
 /* Assemble and emit one reply frame: preamble, Size, obfuscated
@@ -139,6 +145,15 @@ void dock_send_set_vfo_reply(dock_ctx_t *ctx, const dock_vfo_applied_t *r)
     dock_send_payload(ctx, DOCK_REPLY_SET_VFO, p, sizeof(p));
 }
 
+void dock_send_set_mod_reply(dock_ctx_t *ctx, const dock_mod_applied_t *r)
+{
+    /* payload = [0x0878][param_len=4][status:u8][modulation:u8][raw:u8][flags:u8].
+     * `modulation` is the wire value the radio is actually on; `raw` is the radio's
+     * own ModulationMode_t, whose numbering moves with a build flag — see dock.h. */
+    const uint8_t p[4] = { r->status, r->modulation, r->raw, r->flags };
+    dock_send_payload(ctx, DOCK_REPLY_SET_MOD, p, sizeof(p));
+}
+
 /* Little-endian u32 off the wire. Byte-at-a-time rather than a cast, because
  * the payload sits at an arbitrary offset in the RX buffer and this core is
  * compiled for both an ARM target and the host harness. */
@@ -192,6 +207,10 @@ void dock_dispatch(dock_ctx_t *ctx, const uint8_t *payload, uint16_t size)
             vfo.direction    = params[10];
             vfo.narrow       = params[11];
             vfo.power        = params[12];
+            /* NOT from the payload — 0x0873 has no modulation field and must never
+             * grow one (dock.h). This is the session's sticky value, so a tune
+             * cannot silently move the radio off the modulation 0x0877 set. */
+            vfo.modulation   = ctx->modulation;
             /* Refuse nonsense rather than pass it into the radio's own VFO
              * struct. A bad direction byte would otherwise transmit somewhere
              * unintended, which on a repeater input is somebody else's problem,
@@ -213,6 +232,50 @@ void dock_dispatch(dock_ctx_t *ctx, const uint8_t *payload, uint16_t size)
             res.rx_hz = 0; res.tx_hz = 0; res.ctcss_tenths = 0; res.power = 0;
         }
         dock_send_set_vfo_reply(ctx, &res);
+        break;
+    }
+
+    case DOCK_CMD_SET_MODULATION: {
+        /* Like 0x0873, EVERY path answers — including every refusal. And like
+         * 0x0873, the length check is the FIRST branch, before a single field is
+         * decoded and before the binding is reached, which is what makes an EMPTY
+         * 0x0877 a safe firmware-level probe: it cannot move the radio. */
+        dock_mod_applied_t res;
+        memset(&res, 0, sizeof(res));
+
+        if (plen < DOCK_SET_MOD_PARAM_LEN) {
+            res.status = DOCK_MOD_ERR_SHORT;        /* never read past the payload */
+        } else if (ctx->full_control) {
+            res.status = DOCK_MOD_ERR_BUSY;         /* the host owns the chip */
+        } else {
+            const uint8_t want = params[0];
+            /* Refuse, never clamp. A clamped modulation is a radio quietly
+             * demodulating the wrong thing while the reply says it succeeded. */
+            if (want > DOCK_MOD_MAX_ACCEPTED)
+                res.status = DOCK_MOD_ERR_FIELD;
+            else if (!ctx->hal->set_modulation)
+                res.status = DOCK_MOD_ERR_NO_HAL;
+            else {
+                ctx->hal->set_modulation(ctx->hal->user, want, &res);
+                /* Advance the sticky value ONLY on a modulation the radio actually
+                 * took. Committing it during decode would mean a refusal — a BUSY in
+                 * particular — silently changed what the NEXT 0x0873 applies, which
+                 * is the bug this whole mechanism exists to remove, in mirror image. */
+                if (res.status == DOCK_MOD_APPLIED)
+                    ctx->modulation = want;
+            }
+        }
+
+        /* Same unconditional contract as 0x0874, with the sentinel that suits this
+         * payload: a non-zero status never describes a modulation. DOCK_MOD_UNKNOWN
+         * and NOT zero — zero is DOCK_MOD_FM, so blanking to it would answer a
+         * refusal with a plausible claim that the radio is on FM. */
+        if (res.status != DOCK_MOD_APPLIED) {
+            res.modulation = DOCK_MOD_UNKNOWN;
+            res.raw        = DOCK_MOD_UNKNOWN;
+            res.flags      = 0;
+        }
+        dock_send_set_mod_reply(ctx, &res);
         break;
     }
 

--- a/App/app/dock.c
+++ b/App/app/dock.c
@@ -49,10 +49,28 @@ void dock_obfuscate(uint8_t *data, uint16_t len)
         data[i] ^= DOCK_OBF[i % 16];
 }
 
+/* BK4819 REG_30 bit 1 = ENABLE_TX_DSP: set in the app's TX word (0xC1FE),
+ * clear in its RX word (0xBFF1) — the single bit that distinguishes a transmit
+ * key from receive. Defined locally so this core stays free of any firmware-tree
+ * include (mirrors bk4819-regs.h BK4819_REG_30_MASK_ENABLE_TX_DSP). */
+#define DOCK_REG30_TX_DSP 0x0002u
+
+/* Edge-detect the REG_30 TX-enable state and, only on a change, notify the HAL
+ * so it can drive the physical PA. Idempotent: a force-off when already off is a
+ * no-op, so the enter/exit/overflow fail-safe calls never spuriously re-key. */
+static void dock_set_tx(dock_ctx_t *ctx, bool on)
+{
+    if (on == ctx->tx_on) return;
+    ctx->tx_on = on;
+    if (ctx->hal->tx_set)
+        ctx->hal->tx_set(ctx->hal->user, on);
+}
+
 void dock_init(dock_ctx_t *ctx, const dock_hal_t *hal)
 {
     ctx->hal          = hal;
     ctx->full_control = false;
+    ctx->tx_on        = false;
     ctx->len          = 0;
 }
 
@@ -94,10 +112,12 @@ void dock_dispatch(dock_ctx_t *ctx, const uint8_t *payload, uint16_t size)
     switch (opcode) {
     case DOCK_CMD_ENTER_HW:
         ctx->full_control = true;
+        dock_set_tx(ctx, false);   /* fail-safe: never inherit a stale key */
         break;
 
     case DOCK_CMD_EXIT_HW:
         ctx->full_control = false;
+        dock_set_tx(ctx, false);   /* drop the PA before leaving full-control */
         break;
 
     case DOCK_CMD_WRITE_REGS: {
@@ -109,6 +129,10 @@ void dock_dispatch(dock_ctx_t *ctx, const uint8_t *payload, uint16_t size)
             if ((uint32_t)(i + 1) * 4u > avail) break;    /* each pair = 4 bytes */
             const uint16_t reg = (uint16_t)(p[i * 4]     | (p[i * 4 + 1] << 8));
             const uint16_t val = (uint16_t)(p[i * 4 + 2] | (p[i * 4 + 3] << 8));
+            /* Drive the PA on the REG_30 TX-enable edge BEFORE completing the
+             * write (key: PA up then write; un-key: PA down then write). */
+            if (reg == 0x30)
+                dock_set_tx(ctx, (val & DOCK_REG30_TX_DSP) != 0);
             ctx->hal->write_reg(ctx->hal->user, reg, val);
         }
         break;                                            /* no reply */

--- a/App/app/dock.c
+++ b/App/app/dock.c
@@ -125,11 +125,11 @@ void dock_send_register_info(dock_ctx_t *ctx, uint16_t reg, uint16_t value)
 
 void dock_send_set_vfo_reply(dock_ctx_t *ctx, const dock_vfo_applied_t *r)
 {
-    /* payload = [0x0874][param_len=12][status:u8][reserved:u8][rx:u32][tx:u32]
-     * [ctcss_tenths:u16]. The reserved byte is zero and exists so a later flags
-     * field can be added without moving the two frequencies. */
+    /* payload = [0x0874][param_len=12][status:u8][power:u8][rx:u32][tx:u32]
+     * [ctcss_tenths:u16]. `power` is the radio's own OUTPUT_POWER_* value, which
+     * is a different scale from the 0/1/2 the host sends — see dock.h. */
     const uint8_t p[12] = {
-        r->status, 0,
+        r->status, r->power,
         (uint8_t)(r->rx_hz),        (uint8_t)(r->rx_hz >> 8),
         (uint8_t)(r->rx_hz >> 16),  (uint8_t)(r->rx_hz >> 24),
         (uint8_t)(r->tx_hz),        (uint8_t)(r->tx_hz >> 8),
@@ -210,7 +210,7 @@ void dock_dispatch(dock_ctx_t *ctx, const uint8_t *payload, uint16_t size)
          * frequencies. Enforced here rather than trusted to each HAL, so a
          * binding that forgets cannot publish a channel the radio is not on. */
         if (res.status != DOCK_VFO_APPLIED) {
-            res.rx_hz = 0; res.tx_hz = 0; res.ctcss_tenths = 0;
+            res.rx_hz = 0; res.tx_hz = 0; res.ctcss_tenths = 0; res.power = 0;
         }
         dock_send_set_vfo_reply(ctx, &res);
         break;

--- a/App/app/dock.c
+++ b/App/app/dock.c
@@ -1,0 +1,195 @@
+/* Copyright 2026 Kris Bennett (radio-server dock control mode)
+ *
+ * Portions derived from nicsure's "Quansheng Dock" firmware, app/uart.c
+ * (https://github.com/nicsure/quansheng-dock-fw, Apache-2.0): the framing,
+ * the 16-byte XOR obfuscation table, the dummy-CRC reply, and the
+ * register-read/write dispatch. See NOTICE.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+
+#include "app/dock.h"
+
+#include <string.h>
+
+/* 16-byte XOR obfuscation table, identical to the classic dock and to this
+ * tree's app/uart.c Obfuscation[16] (and radio_server frames.py OBFUSCATION). */
+static const uint8_t DOCK_OBF[16] = {
+    0x16, 0x6C, 0x14, 0xE6, 0x2E, 0x91, 0x0D, 0x40,
+    0x21, 0x35, 0xD5, 0x40, 0x13, 0x03, 0xE9, 0x80,
+};
+
+uint16_t dock_crc16(const uint8_t *data, uint16_t len)
+{
+    /* CRC-16/XMODEM: poly 0x1021, init 0, no reflection, no final xor.
+     * Same as this tree's driver/crc.c CRC_Calculate. */
+    uint16_t crc = 0;
+    for (uint16_t i = 0; i < len; i++) {
+        crc ^= (uint16_t)data[i] << 8;
+        for (int j = 0; j < 8; j++)
+            crc = (crc & 0x8000u) ? (uint16_t)((crc << 1) ^ 0x1021u)
+                                  : (uint16_t)(crc << 1);
+    }
+    return crc;
+}
+
+void dock_obfuscate(uint8_t *data, uint16_t len)
+{
+    for (uint16_t i = 0; i < len; i++)
+        data[i] ^= DOCK_OBF[i % 16];
+}
+
+void dock_init(dock_ctx_t *ctx, const dock_hal_t *hal)
+{
+    ctx->hal          = hal;
+    ctx->full_control = false;
+    ctx->len          = 0;
+}
+
+void dock_send_register_info(dock_ctx_t *ctx, uint16_t reg, uint16_t value)
+{
+    /* payload = [0x0951][param_len=4][reg:u16][value:u16], Size = 8. */
+    uint8_t body[8 + 2];
+    body[0] = (uint8_t)(DOCK_REPLY_REG_INFO & 0xFF);
+    body[1] = (uint8_t)(DOCK_REPLY_REG_INFO >> 8);
+    body[2] = 4; body[3] = 0;                 /* param_len */
+    body[4] = (uint8_t)(reg & 0xFF);   body[5] = (uint8_t)(reg >> 8);
+    body[6] = (uint8_t)(value & 0xFF); body[7] = (uint8_t)(value >> 8);
+    const uint16_t size = 8;
+    /* Replies carry a DUMMY CRC: obf(0xFF 0xFF) in the CRC slot. Obfuscate
+     * payload + {0xFF,0xFF} together over Size+2 bytes (matches SendReply). */
+    body[size]     = 0xFF;
+    body[size + 1] = 0xFF;
+    dock_obfuscate(body, size + 2);
+
+    uint8_t frame[2 + 2 + (8 + 2) + 2];
+    uint16_t n = 0;
+    frame[n++] = 0xAB; frame[n++] = 0xCD;                 /* preamble */
+    frame[n++] = (uint8_t)(size & 0xFF);
+    frame[n++] = (uint8_t)(size >> 8);                    /* Size (LE) */
+    memcpy(frame + n, body, size + 2); n += size + 2;     /* obf body + dummy CRC */
+    frame[n++] = 0xDC; frame[n++] = 0xBA;                 /* footer */
+
+    ctx->hal->send(ctx->hal->user, frame, n);
+}
+
+void dock_dispatch(dock_ctx_t *ctx, const uint8_t *payload, uint16_t size)
+{
+    if (size < 4) return;                     /* too short for inner header */
+    const uint16_t opcode = (uint16_t)(payload[0] | (payload[1] << 8));
+    const uint16_t plen   = (uint16_t)(payload[2] | (payload[3] << 8));
+    if ((uint32_t)plen + 4u > size) return;   /* inner length overruns frame */
+    const uint8_t *params = payload + 4;
+
+    switch (opcode) {
+    case DOCK_CMD_ENTER_HW:
+        ctx->full_control = true;
+        break;
+
+    case DOCK_CMD_EXIT_HW:
+        ctx->full_control = false;
+        break;
+
+    case DOCK_CMD_WRITE_REGS: {
+        if (plen < 2) break;
+        const uint16_t count = (uint16_t)(params[0] | (params[1] << 8));
+        const uint8_t *p = params + 2;
+        const uint16_t avail = (uint16_t)(plen - 2);      /* bytes of pair data */
+        for (uint16_t i = 0; i < count; i++) {
+            if ((uint32_t)(i + 1) * 4u > avail) break;    /* each pair = 4 bytes */
+            const uint16_t reg = (uint16_t)(p[i * 4]     | (p[i * 4 + 1] << 8));
+            const uint16_t val = (uint16_t)(p[i * 4 + 2] | (p[i * 4 + 3] << 8));
+            ctx->hal->write_reg(ctx->hal->user, reg, val);
+        }
+        break;                                            /* no reply */
+    }
+
+    case DOCK_CMD_READ_REGS: {
+        if (plen < 2) break;
+        const uint16_t count = (uint16_t)(params[0] | (params[1] << 8));
+        const uint8_t *p = params + 2;
+        const uint16_t avail = (uint16_t)(plen - 2);      /* bytes of register list */
+        for (uint16_t i = 0; i < count; i++) {
+            if ((uint32_t)(i + 1) * 2u > avail) break;    /* each register = 2 bytes */
+            const uint16_t reg = (uint16_t)(p[i * 2] | (p[i * 2 + 1] << 8));
+            const uint16_t val = ctx->hal->read_reg(ctx->hal->user, reg);
+            dock_send_register_info(ctx, reg, val);       /* one 0x0951 per register */
+        }
+        break;
+    }
+
+    default:
+        break;                                            /* unknown -> no reply */
+    }
+}
+
+/* Try to extract and dispatch complete frames from the front of the buffer.
+ * Mirrors app/uart.c UART_IsCommandAvailable + radio_server FirmwareFakeSerial
+ * _consume(): drop-and-resync on any malformed input, never truncate. */
+static void dock_consume(dock_ctx_t *ctx)
+{
+    for (;;) {
+        uint8_t *buf = ctx->buf;
+        uint16_t n   = ctx->len;
+
+        /* Sync to preamble start 0xAB. */
+        uint16_t start = 0;
+        while (start < n && buf[start] != 0xAB) start++;
+        if (start > 0) {
+            memmove(buf, buf + start, n - start);
+            ctx->len = (uint16_t)(n - start);
+            n = ctx->len;
+        }
+        if (n < 4) return;                    /* need preamble + Size */
+        if (buf[1] != 0xCD) {                 /* not 0xCD after 0xAB - advance */
+            memmove(buf, buf + 1, n - 1);
+            ctx->len = (uint16_t)(n - 1);
+            continue;
+        }
+
+        const uint16_t size  = (uint16_t)(buf[2] | (buf[3] << 8));
+        const uint16_t total = (uint16_t)(size + 8);
+        if (size == 0 || size > DOCK_MAX_PAYLOAD) {   /* bogus length - resync */
+            memmove(buf, buf + 2, n - 2);
+            ctx->len = (uint16_t)(n - 2);
+            continue;
+        }
+        if (n < total) return;                /* wait for the rest of the frame */
+
+        const uint16_t footer = (uint16_t)(4 + size + 2);
+        if (buf[footer] != 0xDC || buf[footer + 1] != 0xBA) {  /* bad footer */
+            memmove(buf, buf + 2, n - 2);
+            ctx->len = (uint16_t)(n - 2);
+            continue;
+        }
+
+        /* Accept: de-obfuscate payload + CRC (Size+2 bytes), validate CRC. */
+        uint8_t work[DOCK_MAX_PAYLOAD + 2];
+        memcpy(work, buf + 4, size + 2);
+        dock_obfuscate(work, (uint16_t)(size + 2));
+        const uint16_t crc = (uint16_t)(work[size] | (work[size + 1] << 8));
+        if (dock_crc16(work, size) == crc)
+            dock_dispatch(ctx, work, size);   /* mismatch -> silently dropped */
+
+        /* Consume the whole frame regardless of CRC result. */
+        memmove(buf, buf + total, n - total);
+        ctx->len = (uint16_t)(n - total);
+    }
+}
+
+void dock_rx_byte(dock_ctx_t *ctx, uint8_t b)
+{
+    if (ctx->len >= DOCK_RX_BUF) ctx->len = 0;   /* overflow guard: resync */
+    ctx->buf[ctx->len++] = b;
+    dock_consume(ctx);
+}

--- a/App/app/dock.c
+++ b/App/app/dock.c
@@ -101,6 +101,15 @@ void dock_send_register_info(dock_ctx_t *ctx, uint16_t reg, uint16_t value)
     ctx->hal->send(ctx->hal->user, frame, n);
 }
 
+/* Little-endian u32 off the wire. Byte-at-a-time rather than a cast, because
+ * the payload sits at an arbitrary offset in the RX buffer and this core is
+ * compiled for both an ARM target and the host harness. */
+static uint32_t rd32(const uint8_t *p)
+{
+    return (uint32_t)p[0] | ((uint32_t)p[1] << 8)
+         | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+
 void dock_dispatch(dock_ctx_t *ctx, const uint8_t *payload, uint16_t size)
 {
     if (size < 4) return;                     /* too short for inner header */
@@ -119,6 +128,31 @@ void dock_dispatch(dock_ctx_t *ctx, const uint8_t *payload, uint16_t size)
         ctx->full_control = false;
         dock_set_tx(ctx, false);   /* drop the PA before leaving full-control */
         break;
+
+    case DOCK_CMD_SET_VFO: {
+        /* Set the firmware's VFO so the RADIO retunes itself, rather than
+         * writing registers the 0x0871 exit is going to throw away. See the
+         * long note in dock.h. Silent on every rejection: this command has no
+         * reply, so a caller cannot distinguish "refused" from "applied" on the
+         * wire — it verifies by reading the radio, over the air or on screen. */
+        if (plen < DOCK_SET_VFO_PARAM_LEN) break;   /* short frame: ignore */
+        if (ctx->full_control) break;               /* not while the host owns the chip */
+        dock_vfo_t vfo;
+        vfo.rx_hz        = rd32(params);
+        vfo.offset_hz    = rd32(params + 4);
+        vfo.ctcss_tenths = (uint16_t)(params[8] | (params[9] << 8));
+        vfo.direction    = params[10];
+        vfo.narrow       = params[11];
+        vfo.power        = params[12];
+        /* Refuse nonsense rather than pass it into the radio's own VFO struct.
+         * A bad direction byte would otherwise transmit somewhere unintended,
+         * which on a repeater input is somebody else's problem, not ours. */
+        if (vfo.direction > DOCK_OFFSET_SUB) break;
+        if (vfo.narrow > 1u || vfo.power > 2u) break;
+        if (ctx->hal->set_vfo)
+            ctx->hal->set_vfo(ctx->hal->user, &vfo);
+        break;                                      /* no reply */
+    }
 
     case DOCK_CMD_WRITE_REGS: {
         if (plen < 2) break;

--- a/App/app/dock.c
+++ b/App/app/dock.c
@@ -74,31 +74,69 @@ void dock_init(dock_ctx_t *ctx, const dock_hal_t *hal)
     ctx->len          = 0;
 }
 
-void dock_send_register_info(dock_ctx_t *ctx, uint16_t reg, uint16_t value)
+/* Longest parameter block this core replies with (0x0874's 12; 0x0951 uses 4).
+ * Named rather than implied by the largest caller, so adding a reply that does
+ * not fit is a compile-time size check instead of a stack overrun. */
+#define DOCK_REPLY_MAX_PARAMS 12u
+
+/* Assemble and emit one reply frame: preamble, Size, obfuscated
+ * [opcode][param_len][params] + dummy CRC, footer. */
+static void dock_send_payload(dock_ctx_t *ctx, uint16_t opcode,
+                              const uint8_t *params, uint16_t plen)
 {
-    /* payload = [0x0951][param_len=4][reg:u16][value:u16], Size = 8. */
-    uint8_t body[8 + 2];
-    body[0] = (uint8_t)(DOCK_REPLY_REG_INFO & 0xFF);
-    body[1] = (uint8_t)(DOCK_REPLY_REG_INFO >> 8);
-    body[2] = 4; body[3] = 0;                 /* param_len */
-    body[4] = (uint8_t)(reg & 0xFF);   body[5] = (uint8_t)(reg >> 8);
-    body[6] = (uint8_t)(value & 0xFF); body[7] = (uint8_t)(value >> 8);
-    const uint16_t size = 8;
+    if (plen > DOCK_REPLY_MAX_PARAMS) return;   /* unreachable; see the #define */
+
+    uint8_t body[4 + DOCK_REPLY_MAX_PARAMS + 2];
+    const uint16_t size = (uint16_t)(4 + plen);
+    body[0] = (uint8_t)(opcode & 0xFF);
+    body[1] = (uint8_t)(opcode >> 8);
+    body[2] = (uint8_t)(plen & 0xFF);
+    body[3] = (uint8_t)(plen >> 8);
+    if (plen)
+        memcpy(body + 4, params, plen);
+
     /* Replies carry a DUMMY CRC: obf(0xFF 0xFF) in the CRC slot. Obfuscate
      * payload + {0xFF,0xFF} together over Size+2 bytes (matches SendReply). */
     body[size]     = 0xFF;
     body[size + 1] = 0xFF;
-    dock_obfuscate(body, size + 2);
+    dock_obfuscate(body, (uint16_t)(size + 2));
 
-    uint8_t frame[2 + 2 + (8 + 2) + 2];
+    uint8_t frame[2 + 2 + (4 + DOCK_REPLY_MAX_PARAMS + 2) + 2];
     uint16_t n = 0;
     frame[n++] = 0xAB; frame[n++] = 0xCD;                 /* preamble */
     frame[n++] = (uint8_t)(size & 0xFF);
     frame[n++] = (uint8_t)(size >> 8);                    /* Size (LE) */
-    memcpy(frame + n, body, size + 2); n += size + 2;     /* obf body + dummy CRC */
+    memcpy(frame + n, body, (size_t)(size + 2));
+    n = (uint16_t)(n + size + 2);                         /* obf body + dummy CRC */
     frame[n++] = 0xDC; frame[n++] = 0xBA;                 /* footer */
 
     ctx->hal->send(ctx->hal->user, frame, n);
+}
+
+void dock_send_register_info(dock_ctx_t *ctx, uint16_t reg, uint16_t value)
+{
+    /* payload = [0x0951][param_len=4][reg:u16][value:u16], Size = 8. */
+    const uint8_t p[4] = {
+        (uint8_t)(reg & 0xFF),   (uint8_t)(reg >> 8),
+        (uint8_t)(value & 0xFF), (uint8_t)(value >> 8),
+    };
+    dock_send_payload(ctx, DOCK_REPLY_REG_INFO, p, sizeof(p));
+}
+
+void dock_send_set_vfo_reply(dock_ctx_t *ctx, const dock_vfo_applied_t *r)
+{
+    /* payload = [0x0874][param_len=12][status:u8][reserved:u8][rx:u32][tx:u32]
+     * [ctcss_tenths:u16]. The reserved byte is zero and exists so a later flags
+     * field can be added without moving the two frequencies. */
+    const uint8_t p[12] = {
+        r->status, 0,
+        (uint8_t)(r->rx_hz),        (uint8_t)(r->rx_hz >> 8),
+        (uint8_t)(r->rx_hz >> 16),  (uint8_t)(r->rx_hz >> 24),
+        (uint8_t)(r->tx_hz),        (uint8_t)(r->tx_hz >> 8),
+        (uint8_t)(r->tx_hz >> 16),  (uint8_t)(r->tx_hz >> 24),
+        (uint8_t)(r->ctcss_tenths), (uint8_t)(r->ctcss_tenths >> 8),
+    };
+    dock_send_payload(ctx, DOCK_REPLY_SET_VFO, p, sizeof(p));
 }
 
 /* Little-endian u32 off the wire. Byte-at-a-time rather than a cast, because
@@ -132,26 +170,50 @@ void dock_dispatch(dock_ctx_t *ctx, const uint8_t *payload, uint16_t size)
     case DOCK_CMD_SET_VFO: {
         /* Set the firmware's VFO so the RADIO retunes itself, rather than
          * writing registers the 0x0871 exit is going to throw away. See the
-         * long note in dock.h. Silent on every rejection: this command has no
-         * reply, so a caller cannot distinguish "refused" from "applied" on the
-         * wire — it verifies by reading the radio, over the air or on screen. */
-        if (plen < DOCK_SET_VFO_PARAM_LEN) break;   /* short frame: ignore */
-        if (ctx->full_control) break;               /* not while the host owns the chip */
-        dock_vfo_t vfo;
-        vfo.rx_hz        = rd32(params);
-        vfo.offset_hz    = rd32(params + 4);
-        vfo.ctcss_tenths = (uint16_t)(params[8] | (params[9] << 8));
-        vfo.direction    = params[10];
-        vfo.narrow       = params[11];
-        vfo.power        = params[12];
-        /* Refuse nonsense rather than pass it into the radio's own VFO struct.
-         * A bad direction byte would otherwise transmit somewhere unintended,
-         * which on a repeater input is somebody else's problem, not ours. */
-        if (vfo.direction > DOCK_OFFSET_SUB) break;
-        if (vfo.narrow > 1u || vfo.power > 2u) break;
-        if (ctx->hal->set_vfo)
-            ctx->hal->set_vfo(ctx->hal->user, &vfo);
-        break;                                      /* no reply */
+         * long note in dock.h.
+         *
+         * EVERY path below answers 0x0874, including every refusal. The first
+         * draft of this command was silent, which made "refused" and "applied"
+         * the same event on the wire — and this is the one command whose result
+         * outlives the dock session, so a caller that cannot tell them apart
+         * walks away believing the radio is on a channel it never reached. */
+        dock_vfo_applied_t res;
+        memset(&res, 0, sizeof(res));
+
+        if (plen < DOCK_SET_VFO_PARAM_LEN) {
+            res.status = DOCK_VFO_ERR_SHORT;        /* never read past the payload */
+        } else if (ctx->full_control) {
+            res.status = DOCK_VFO_ERR_BUSY;         /* the host owns the chip */
+        } else {
+            dock_vfo_t vfo;
+            vfo.rx_hz        = rd32(params);
+            vfo.offset_hz    = rd32(params + 4);
+            vfo.ctcss_tenths = (uint16_t)(params[8] | (params[9] << 8));
+            vfo.direction    = params[10];
+            vfo.narrow       = params[11];
+            vfo.power        = params[12];
+            /* Refuse nonsense rather than pass it into the radio's own VFO
+             * struct. A bad direction byte would otherwise transmit somewhere
+             * unintended, which on a repeater input is somebody else's problem,
+             * not ours. */
+            if (vfo.direction > DOCK_OFFSET_SUB)
+                res.status = DOCK_VFO_ERR_DIRECTION;
+            else if (vfo.narrow > 1u || vfo.power > 2u)
+                res.status = DOCK_VFO_ERR_FIELD;
+            else if (!ctx->hal->set_vfo)
+                res.status = DOCK_VFO_ERR_NO_HAL;
+            else
+                ctx->hal->set_vfo(ctx->hal->user, &vfo, &res);
+        }
+
+        /* The wire contract is unconditional: a non-zero status never carries
+         * frequencies. Enforced here rather than trusted to each HAL, so a
+         * binding that forgets cannot publish a channel the radio is not on. */
+        if (res.status != DOCK_VFO_APPLIED) {
+            res.rx_hz = 0; res.tx_hz = 0; res.ctcss_tenths = 0;
+        }
+        dock_send_set_vfo_reply(ctx, &res);
+        break;
     }
 
     case DOCK_CMD_WRITE_REGS: {

--- a/App/app/dock.h
+++ b/App/app/dock.h
@@ -57,11 +57,52 @@
 #define DOCK_CMD_READ_REGS  0x0851u
 #define DOCK_CMD_ENTER_HW   0x0870u
 #define DOCK_CMD_EXIT_HW    0x0871u
+#define DOCK_CMD_SET_VFO    0x0872u
 #define DOCK_REPLY_REG_INFO 0x0951u
 
 /* Payload cap: matches radio_server frames.py MAX_PAYLOAD_SIZE (254). */
 #define DOCK_MAX_PAYLOAD 254u
 #define DOCK_RX_BUF      (DOCK_MAX_PAYLOAD + 10u)
+
+/* ---- 0x0872 set-VFO ------------------------------------------------------
+ *
+ * Everything else in this protocol writes BK4819 registers, and none of it
+ * survives the handoff back to the radio: 0x0870 backs the registers up and
+ * 0x0871 ends in RADIO_SetupRegisters(true), which retunes the synthesiser
+ * from the radio's OWN VFO (app/uart.c Dock_EnterFullControl -> radio.c
+ * "BK4819_SetFrequency(gRxVfo->pRX->Frequency)"). So a host that tunes by
+ * register can never hand the radio a channel and walk away.
+ *
+ * 0x0872 sets the firmware's VFO instead, and then lets the firmware's own
+ * RADIO_ApplyOffset / RADIO_ConfigureSquelchAndOutputPower / RADIO_SetupRegisters
+ * do the work. After it, the radio is genuinely on the channel — screen, split,
+ * CTCSS, and the per-band PA calibration the host cannot read out of flash —
+ * exactly as if a thumb had dialled it. It is deliberately NOT part of the
+ * full-control loop: a one-shot command, so the firmware main loop is never
+ * starved (that starvation is what makes the radio ignore its own PTT pin).
+ */
+#define DOCK_SET_VFO_PARAM_LEN 13u
+
+/* Offset direction, matching the firmware's TX_OFFSET_FREQUENCY_DIRECTION. */
+#define DOCK_OFFSET_NONE 0u
+#define DOCK_OFFSET_ADD  1u
+#define DOCK_OFFSET_SUB  2u
+
+/* One repeater channel, decoded from the wire.
+ *
+ * `ctcss_tenths` is tenths of a Hz (1000 = 100.0 Hz), 0 for none, so the wire
+ * carries the tone itself rather than an index into a table both sides would
+ * have to agree on for ever — the firmware resolves it against its own
+ * CTCSS_Options, which is the only table that can be wrong in a way that
+ * matters. */
+typedef struct {
+    uint32_t rx_hz;
+    uint32_t offset_hz;
+    uint16_t ctcss_tenths;
+    uint8_t  direction;     /* DOCK_OFFSET_* */
+    uint8_t  narrow;        /* 0 = wide FM, 1 = narrow */
+    uint8_t  power;         /* 0 low, 1 mid, 2 high */
+} dock_vfo_t;
 
 /* Thin hardware seam. Firmware binds these to BK4819_ReadRegister /
  * BK4819_WriteRegister / UART_Send; the host harness binds fakes. */
@@ -76,6 +117,12 @@ typedef struct {
      * REG_30 write leaves dark (F5 / radio-server Chain B). on=true on key,
      * on=false on un-key and at the fail-safe seams (enter/exit/overflow). */
     void     (*tx_set)(void *user, bool on);
+    /* Optional (may be NULL). Called on a validated 0x0872 with a decoded
+     * channel. The firmware binds this to its own RADIO_* chain; the host
+     * harness binds a spy. Never called while full_control is set — applying a
+     * VFO mid-dock would reprogram the chip under the host's feet, which is the
+     * "adopt whatever state you find" fault class ADR 0132 removed. */
+    void     (*set_vfo)(void *user, const dock_vfo_t *vfo);
 } dock_hal_t;
 
 typedef struct {

--- a/App/app/dock.h
+++ b/App/app/dock.h
@@ -70,11 +70,18 @@ typedef struct {
     void     (*write_reg)(void *user, uint16_t reg, uint16_t value);
     void     (*send)(void *user, const uint8_t *buf, uint16_t len);
     void     *user;
+    /* Optional (may be NULL). Called on a REG_30 TX-enable *edge* — before the
+     * register write completes — so the firmware can engage/disengage the
+     * external PA chain (REG_33 PA-enable GPIO + REG_36 bias) that a bare
+     * REG_30 write leaves dark (F5 / radio-server Chain B). on=true on key,
+     * on=false on un-key and at the fail-safe seams (enter/exit/overflow). */
+    void     (*tx_set)(void *user, bool on);
 } dock_hal_t;
 
 typedef struct {
     const dock_hal_t *hal;
     bool     full_control;   /* set by 0x0870, cleared by 0x0871 */
+    bool     tx_on;          /* cached REG_30 TX-enable state, for edge-detect */
     uint8_t  buf[DOCK_RX_BUF];
     uint16_t len;
 } dock_ctx_t;

--- a/App/app/dock.h
+++ b/App/app/dock.h
@@ -1,0 +1,104 @@
+/* Copyright 2026 Kris Bennett (radio-server dock control mode)
+ *
+ * Portions derived from nicsure's "Quansheng Dock" firmware, app/uart.c
+ * (https://github.com/nicsure/quansheng-dock-fw, Apache-2.0). See NOTICE.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+
+/*
+ * dock.h - pure, host-compilable UV-K5 "dock control mode" protocol core.
+ *
+ * This module implements ONLY the wire surface radio-server drives:
+ *   0x0850 write-registers, 0x0851 read-registers -> 0x0951 RegisterInfo,
+ *   0x0870 enter / 0x0871 exit full-control.
+ * No keypress-sim, screen, scan, GPIO or modulation commands (radio-server
+ * does everything through BK4819 registers).
+ *
+ * It is deliberately free of any hardware or firmware-tree include so it can
+ * be compiled and unit-tested on the host. All hardware access (BK4819 read/
+ * write, UART byte-out) is reached through a caller-supplied dock_hal_t. The
+ * definition of "correct" is byte-compatibility with radio-server's
+ * FirmwareFakeSerial + Uvk5Decoder (radio_server/backends/uvk5/); the host
+ * harness in tests/host/ mirrors that fake's rules.
+ *
+ * Wire framing (identical to the classic Quansheng Dock / the fake):
+ *   [0xAB 0xCD][Size:u16 LE][ obf( payload[Size] + CRC[2] ) ][0xDC 0xBA]
+ *   payload = [opcode:u16 LE][param_len:u16 LE][params...], Size = 4+param_len.
+ *   Inbound COMMAND frames carry a real CRC-16/XMODEM over the plaintext
+ *   payload (validated; mismatch dropped). Outbound REPLY frames carry a
+ *   DUMMY obf(0xFF 0xFF) in the CRC slot, never a real CRC.
+ *
+ * Obfuscation is always on (this V3 tree hard-defines bIsEncrypted == true,
+ * and radio-server's dock transport always obfuscates); the classic dock's
+ * plaintext-0x0514 encryption toggle is intentionally not implemented here
+ * because no frame radio-server sends to a working dock exercises it.
+ */
+
+#ifndef APP_DOCK_H
+#define APP_DOCK_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* Wire opcodes (little-endian on the wire). */
+#define DOCK_CMD_WRITE_REGS 0x0850u
+#define DOCK_CMD_READ_REGS  0x0851u
+#define DOCK_CMD_ENTER_HW   0x0870u
+#define DOCK_CMD_EXIT_HW    0x0871u
+#define DOCK_REPLY_REG_INFO 0x0951u
+
+/* Payload cap: matches radio_server frames.py MAX_PAYLOAD_SIZE (254). */
+#define DOCK_MAX_PAYLOAD 254u
+#define DOCK_RX_BUF      (DOCK_MAX_PAYLOAD + 10u)
+
+/* Thin hardware seam. Firmware binds these to BK4819_ReadRegister /
+ * BK4819_WriteRegister / UART_Send; the host harness binds fakes. */
+typedef struct {
+    uint16_t (*read_reg)(void *user, uint16_t reg);
+    void     (*write_reg)(void *user, uint16_t reg, uint16_t value);
+    void     (*send)(void *user, const uint8_t *buf, uint16_t len);
+    void     *user;
+} dock_hal_t;
+
+typedef struct {
+    const dock_hal_t *hal;
+    bool     full_control;   /* set by 0x0870, cleared by 0x0871 */
+    uint8_t  buf[DOCK_RX_BUF];
+    uint16_t len;
+} dock_ctx_t;
+
+void dock_init(dock_ctx_t *ctx, const dock_hal_t *hal);
+
+/* Dispatch ONE already-de-obfuscated, CRC-validated payload
+ * ([opcode:u16][param_len:u16][params], size = 4+param_len). This is the
+ * shared core the firmware calls from its top-level command handler and that
+ * the deframer below calls on each accepted frame. */
+void dock_dispatch(dock_ctx_t *ctx, const uint8_t *payload, uint16_t size);
+
+/* Streaming deframer mirroring UART_IsCommandAvailable's acceptance rules
+ * (sync AB CD, size bound, footer DC BA, de-obfuscate, validate command CRC,
+ * drop-and-resync on any mismatch, oversize dropped not truncated). On each
+ * accepted frame it calls dock_dispatch. Host-harness entry point. */
+void dock_rx_byte(dock_ctx_t *ctx, uint8_t b);
+
+/* Build and send a single 0x0951 RegisterInfo reply (obfuscated body, dummy
+ * obf(0xFF 0xFF) CRC slot). Exposed for the harness. */
+void dock_send_register_info(dock_ctx_t *ctx, uint16_t reg, uint16_t value);
+
+/* Framing primitives (exposed for the harness). CRC-16/XMODEM. */
+uint16_t dock_crc16(const uint8_t *data, uint16_t len);
+void     dock_obfuscate(uint8_t *data, uint16_t len); /* self-inverse XOR */
+
+#endif /* APP_DOCK_H */

--- a/App/app/dock.h
+++ b/App/app/dock.h
@@ -59,12 +59,13 @@
 #define DOCK_CMD_EXIT_HW    0x0871u
 #define DOCK_CMD_SET_VFO    0x0873u
 #define DOCK_REPLY_REG_INFO 0x0951u
+#define DOCK_REPLY_SET_VFO  0x0874u
 
 /* Payload cap: matches radio_server frames.py MAX_PAYLOAD_SIZE (254). */
 #define DOCK_MAX_PAYLOAD 254u
 #define DOCK_RX_BUF      (DOCK_MAX_PAYLOAD + 10u)
 
-/* ---- 0x0872 set-VFO ------------------------------------------------------
+/* ---- 0x0873 set-VFO, and its 0x0874 reply --------------------------------
  *
  * Everything else in this protocol writes BK4819 registers, and none of it
  * survives the handoff back to the radio: 0x0870 backs the registers up and
@@ -73,15 +74,62 @@
  * "BK4819_SetFrequency(gRxVfo->pRX->Frequency)"). So a host that tunes by
  * register can never hand the radio a channel and walk away.
  *
- * 0x0872 sets the firmware's VFO instead, and then lets the firmware's own
+ * 0x0873 sets the firmware's VFO instead, and then lets the firmware's own
  * RADIO_ApplyOffset / RADIO_ConfigureSquelchAndOutputPower / RADIO_SetupRegisters
  * do the work. After it, the radio is genuinely on the channel — screen, split,
  * CTCSS, and the per-band PA calibration the host cannot read out of flash —
  * exactly as if a thumb had dialled it. It is deliberately NOT part of the
  * full-control loop: a one-shot command, so the firmware main loop is never
  * starved (that starvation is what makes the radio ignore its own PTT pin).
+ *
+ * WHY IT REPLIES (0x0874), when the first draft of it did not.
+ *
+ * This command had five ways to do nothing at all and no way to say so: a short
+ * frame, full-control held, a bad direction, a bad bandwidth/power, and a tone
+ * the radio's table does not contain (which fell through to "no tone" — the
+ * repeater then simply never opens). The host saw a successful write either
+ * way. That is the exact fault class this fork keeps paying for: radio-server
+ * ADR 0140/0141 spent four cycles on an intermittency because "no measurement"
+ * and "no signal" were indistinguishable, and the tune here is *more* dangerous
+ * than a register write, because a register write is undone by the next 0x0871
+ * while a wrong VFO is what the radio transmits on after everyone walks away.
+ *
+ * So every 0x0873 now answers with a status AND the frequencies the radio
+ * actually ended up on, read back out of its own VFO struct after
+ * RADIO_ApplyOffset. Not the values the host asked for — the ones it got.
+ *
+ * UNITS: the wire carries plain Hz, both ways. The firmware's own VFO stores
+ * frequency in units of 10 Hz (App/frequencies.c frequencyBandTable has 400 MHz
+ * as 40000000), so app/uart.c converts on the way in and back on the way out.
+ * Getting this wrong is not a small error and it is not a loud one:
+ * FREQUENCY_GetBand() CLAMPS instead of failing, so 448525000 taken as 10 Hz
+ * units resolves to BAND7_470MHz and programmes the synthesiser for 4.485 GHz
+ * with band-7 PA calibration — no error anywhere, and no RF where anyone is
+ * listening.
  */
 #define DOCK_SET_VFO_PARAM_LEN 13u
+
+/* 0x0874 status byte. 0 is the only success; every other value names a distinct
+ * reason the radio is NOT on the channel that was asked for. */
+#define DOCK_VFO_APPLIED        0u  /* on the channel, exactly as requested   */
+#define DOCK_VFO_ERR_SHORT      1u  /* payload shorter than the parameter set */
+#define DOCK_VFO_ERR_BUSY       2u  /* host holds full-control (0x0870)       */
+#define DOCK_VFO_ERR_DIRECTION  3u  /* offset direction not NONE/ADD/SUB      */
+#define DOCK_VFO_ERR_FIELD      4u  /* bandwidth or power off its scale       */
+#define DOCK_VFO_ERR_NO_HAL     5u  /* built without the radio-side binding   */
+#define DOCK_VFO_ERR_BAND       6u  /* rx or tx leg outside every band        */
+#define DOCK_VFO_ERR_TONE       7u  /* tone absent from CTCSS_Options; VFO is
+                                     * on frequency but would key WITHOUT the
+                                     * tone, so the repeater stays shut       */
+
+/* What the radio ended up on, read back after the firmware's own RADIO_ApplyOffset.
+ * Frequencies in Hz. On any rejection these are zero. */
+typedef struct {
+    uint32_t rx_hz;
+    uint32_t tx_hz;         /* the leg that actually radiates */
+    uint16_t ctcss_tenths;  /* as applied; 0 = transmitting no tone */
+    uint8_t  status;        /* DOCK_VFO_* */
+} dock_vfo_applied_t;
 
 /* Offset direction, matching the firmware's TX_OFFSET_FREQUENCY_DIRECTION. */
 #define DOCK_OFFSET_NONE 0u
@@ -96,8 +144,8 @@
  * CTCSS_Options, which is the only table that can be wrong in a way that
  * matters. */
 typedef struct {
-    uint32_t rx_hz;
-    uint32_t offset_hz;
+    uint32_t rx_hz;         /* Hz, as sent — NOT the firmware's 10 Hz units */
+    uint32_t offset_hz;     /* Hz */
     uint16_t ctcss_tenths;
     uint8_t  direction;     /* DOCK_OFFSET_* */
     uint8_t  narrow;        /* 0 = wide FM, 1 = narrow */
@@ -117,12 +165,18 @@ typedef struct {
      * REG_30 write leaves dark (F5 / radio-server Chain B). on=true on key,
      * on=false on un-key and at the fail-safe seams (enter/exit/overflow). */
     void     (*tx_set)(void *user, bool on);
-    /* Optional (may be NULL). Called on a validated 0x0872 with a decoded
-     * channel. The firmware binds this to its own RADIO_* chain; the host
-     * harness binds a spy. Never called while full_control is set — applying a
-     * VFO mid-dock would reprogram the chip under the host's feet, which is the
-     * "adopt whatever state you find" fault class ADR 0132 removed. */
-    void     (*set_vfo)(void *user, const dock_vfo_t *vfo);
+    /* Optional (may be NULL — then 0x0873 answers DOCK_VFO_ERR_NO_HAL). Called
+     * on a validated 0x0873 with a decoded channel. The firmware binds this to
+     * its own RADIO_* chain; the host harness binds a spy. Never called while
+     * full_control is set — applying a VFO mid-dock would reprogram the chip
+     * under the host's feet, which is the "adopt whatever state you find" fault
+     * class ADR 0132 removed.
+     *
+     * MUST fill `out`: `status` DOCK_VFO_APPLIED plus the frequencies the radio
+     * is now on, or a DOCK_VFO_ERR_* it alone can detect (band, tone) with the
+     * frequencies left zero. It reports what happened; it does not re-validate
+     * what dock.c already checked. */
+    void     (*set_vfo)(void *user, const dock_vfo_t *vfo, dock_vfo_applied_t *out);
 } dock_hal_t;
 
 typedef struct {
@@ -150,6 +204,9 @@ void dock_rx_byte(dock_ctx_t *ctx, uint8_t b);
 /* Build and send a single 0x0951 RegisterInfo reply (obfuscated body, dummy
  * obf(0xFF 0xFF) CRC slot). Exposed for the harness. */
 void dock_send_register_info(dock_ctx_t *ctx, uint16_t reg, uint16_t value);
+
+/* Build and send the 0x0874 set-VFO reply. Exposed for the harness. */
+void dock_send_set_vfo_reply(dock_ctx_t *ctx, const dock_vfo_applied_t *r);
 
 /* Framing primitives (exposed for the harness). CRC-16/XMODEM. */
 uint16_t dock_crc16(const uint8_t *data, uint16_t len);

--- a/App/app/dock.h
+++ b/App/app/dock.h
@@ -123,12 +123,19 @@
                                      * tone, so the repeater stays shut       */
 
 /* What the radio ended up on, read back after the firmware's own RADIO_ApplyOffset.
- * Frequencies in Hz. On any rejection these are zero. */
+ * Frequencies in Hz. On any rejection these are zero.
+ *
+ * `power` is the radio's OWN OUTPUT_POWER_* value, not the 0/1/2 that was sent.
+ * It is reported because the two scales are not the same and quietly disagreed:
+ * the wire's "high" (2) landed on OUTPUT_POWER_LOW2 in an enum that runs
+ * USER, LOW1..LOW5, MID, HIGH. A repeater simply does not open at that level,
+ * and nothing about it is visible from the host. */
 typedef struct {
     uint32_t rx_hz;
     uint32_t tx_hz;         /* the leg that actually radiates */
     uint16_t ctcss_tenths;  /* as applied; 0 = transmitting no tone */
     uint8_t  status;        /* DOCK_VFO_* */
+    uint8_t  power;         /* the firmware's OUTPUT_POWER_*, as applied */
 } dock_vfo_applied_t;
 
 /* Offset direction, matching the firmware's TX_OFFSET_FREQUENCY_DIRECTION. */

--- a/App/app/dock.h
+++ b/App/app/dock.h
@@ -57,7 +57,7 @@
 #define DOCK_CMD_READ_REGS  0x0851u
 #define DOCK_CMD_ENTER_HW   0x0870u
 #define DOCK_CMD_EXIT_HW    0x0871u
-#define DOCK_CMD_SET_VFO    0x0872u
+#define DOCK_CMD_SET_VFO    0x0873u
 #define DOCK_REPLY_REG_INFO 0x0951u
 
 /* Payload cap: matches radio_server frames.py MAX_PAYLOAD_SIZE (254). */

--- a/App/app/dock.h
+++ b/App/app/dock.h
@@ -21,9 +21,11 @@
  *
  * This module implements ONLY the wire surface radio-server drives:
  *   0x0850 write-registers, 0x0851 read-registers -> 0x0951 RegisterInfo,
- *   0x0870 enter / 0x0871 exit full-control.
- * No keypress-sim, screen, scan, GPIO or modulation commands (radio-server
- * does everything through BK4819 registers).
+ *   0x0870 enter / 0x0871 exit full-control,
+ *   0x0873 set-VFO -> 0x0874 (F6), 0x0877 set-modulation -> 0x0878 (F7).
+ * No keypress-sim, screen, scan or GPIO commands. The register commands are how
+ * radio-server drives the chip; 0x0873 and 0x0877 exist because register writes
+ * do not survive the 0x0871 handoff (see the long note below).
  *
  * It is deliberately free of any hardware or firmware-tree include so it can
  * be compiled and unit-tested on the host. All hardware access (BK4819 read/
@@ -53,13 +55,23 @@
 #include <stdint.h>
 
 /* Wire opcodes (little-endian on the wire). */
-#define DOCK_CMD_WRITE_REGS 0x0850u
-#define DOCK_CMD_READ_REGS  0x0851u
-#define DOCK_CMD_ENTER_HW   0x0870u
-#define DOCK_CMD_EXIT_HW    0x0871u
-#define DOCK_CMD_SET_VFO    0x0873u
-#define DOCK_REPLY_REG_INFO 0x0951u
-#define DOCK_REPLY_SET_VFO  0x0874u
+#define DOCK_CMD_WRITE_REGS     0x0850u
+#define DOCK_CMD_READ_REGS      0x0851u
+#define DOCK_CMD_ENTER_HW       0x0870u
+#define DOCK_CMD_EXIT_HW        0x0871u
+#define DOCK_CMD_SET_VFO        0x0873u
+/* 0x0877, NOT 0x0875. radio-server ADR 0111 records the classic Quansheng Dock's
+ * full-control extended set as "0x0872 modulation, 0x0873/4 backlight, 0x0875/6 AM
+ * emulation", so 0x0875/6 is claimed. That census cannot be re-verified from this
+ * tree (nicsure's source is not vendored here) and is therefore treated as claimed
+ * rather than assumed free — which is exactly the check 0x0873's own allocation
+ * skipped: ADR 0140 reasoned only about 0x0872 and took a pair the same census had
+ * already spoken for. That one is shipped and cannot be walked back. This one is
+ * cheap to place correctly, so it is placed correctly. */
+#define DOCK_CMD_SET_MODULATION 0x0877u
+#define DOCK_REPLY_REG_INFO     0x0951u
+#define DOCK_REPLY_SET_VFO      0x0874u
+#define DOCK_REPLY_SET_MOD      0x0878u
 
 /* Payload cap: matches radio_server frames.py MAX_PAYLOAD_SIZE (254). */
 #define DOCK_MAX_PAYLOAD 254u
@@ -143,7 +155,121 @@ typedef struct {
 #define DOCK_OFFSET_ADD  1u
 #define DOCK_OFFSET_SUB  2u
 
-/* One repeater channel, decoded from the wire.
+/* ---- 0x0877 set-modulation, and its 0x0878 reply -------------------------
+ *
+ * WHY A NEW OPCODE AND NOT A 14TH BYTE ON 0x0873.
+ *
+ * A field appended to 0x0873 changes the bytes of a frame radio-server already
+ * sends, and it breaks in BOTH directions, silently. Old host + new firmware: the
+ * 13-byte frame is refused DOCK_VFO_ERR_SHORT, which the host reads as a tuning
+ * failure rather than as a version mismatch. New host + old firmware: the 14-byte
+ * frame decodes fine, the 14th byte is ignored, and the radio tunes on a
+ * modulation nobody set. A new opcode is additive instead — an old host never
+ * sends it, and a new host sending it to a pre-F7 firmware falls through
+ * dock_dispatch's `default:` to no reply at all, which is the same silence the
+ * F-level probe already reads.
+ *
+ * THE WIRE HAS ITS OWN VALUES, ON PURPOSE.
+ *
+ * The firmware's ModulationMode_t (radio.h) is { FM, AM, USB, [BYP, RAW,]
+ * UKNOWN } — the bracketed pair exists only under ENABLE_BYP_RAW_DEMODULATORS, so
+ * the enum's numeric END MOVES WITH A BUILD FLAG. A wire bound derived from it
+ * would mean different things in two builds of the same protocol, and this core
+ * may not include a firmware header anyway. So the wire names its own values and
+ * app/uart.c maps them explicitly, in both directions. That is the DOCK_POWER_MAP
+ * lesson (see below) applied before it bites rather than after.
+ *
+ * THE MODULATION IS STICKY FOR THE SESSION, AND THAT IS THE POINT.
+ *
+ * 0x0873 has to write SOME modulation into the VFO it applies. It used to write
+ * MODULATION_FM literally, so "set AM, then tune" silently landed the radio back
+ * on FM. Sending the two as separate frames is not merely inconvenient, it is
+ * unreliable: ADR 0131 established that this link DROPS frames — the firmware is
+ * single-threaded and anything arriving while it is busy is discarded, not queued.
+ * Tune lands, set-modulation is dropped, and the radio sits on the right channel
+ * in the wrong demodulator with nothing on the wire having said so.
+ *
+ * So dock_ctx_t carries the modulation and 0x0873 applies it. After one successful
+ * 0x0877 every later tune keeps it, and a dropped frame is a retryable 0x0877
+ * instead of a silently mis-configured radio. It is SEEDED FROM A CONSTANT and
+ * never from a read of the radio: seeding it from the radio's current state is the
+ * "adopt whatever you find" fault ADR 0132 removed, and it would hand a repeater
+ * channel whatever demodulator the last person left on the front panel. Seeded FM,
+ * so a host that never sends 0x0877 gets byte-identical F6 behaviour.
+ *
+ * It is SESSION state, not radio state: Dock_EnsureInit runs once per radio power
+ * cycle, so it outlives a host process restart. A reconnecting host must ASSERT the
+ * modulation it wants rather than assume FM. That is a requirement on the host, not
+ * a note.
+ *
+ * NON-FM STOPS THE RADIO'S OWN TRANSMIT PATH.
+ *
+ * Built without ENABLE_TX_WHEN_AM (which this tree is not), RADIO_PrepareTX sets
+ * VFO_STATE_TX_DISABLE for any modulation that is not FM (radio.c). That path is
+ * how the radio's PTT PIN keys — and radio-server's baofeng backend keys exactly
+ * there, by asserting the AIOC's DTR line into that pin. So on that station a
+ * successful set-AM stops the transmitter outright. The dock's own REG_30 keying
+ * (0x0850) does not go through RADIO_PrepareTX and is NOT blocked, so the same
+ * firmware state means "cannot transmit" on one backend and "transmits normally" on
+ * another. A host cannot see a build flag, so DOCK_MOD_FLAG_TX_OK reports it.
+ * The flag REPORTS the condition; it does not remove it. AM is receive-only here.
+ */
+#define DOCK_SET_MOD_PARAM_LEN 1u
+
+/* Wire modulation values. Deliberately NOT ModulationMode_t — see above. */
+#define DOCK_MOD_FM  0u
+#define DOCK_MOD_AM  1u
+/* Reserved: the NUMBER is nailed down so it can never mean anything else, but the
+ * VALUE is refused at F7 (DOCK_MOD_ERR_FIELD). Nobody has put this radio on USB on
+ * a bench, it cannot transmit in it on this build anyway, and a refusal never moves
+ * the radio — so accepting it later is purely additive, while shipping it now would
+ * be a confident answer nobody has checked. Guardrail 1. */
+#define DOCK_MOD_USB 2u
+#define DOCK_MOD_MAX_ACCEPTED DOCK_MOD_AM
+
+/* Reply-only: the radio is on something this wire cannot name (BYP/RAW on a build
+ * that has them, or anything a future firmware adds), OR the request was refused.
+ *
+ * NOT zero. 0x0874 blanks its frequency fields to 0 on a refusal because 0 Hz is
+ * obviously not a channel; copying that literally here would blank modulation to 0,
+ * which IS DOCK_MOD_FM — a refusal that ships a plausible claim the radio is on FM.
+ * Same principle, correct sentinel. */
+#define DOCK_MOD_UNKNOWN 0xFFu
+
+/* 0x0878 flags. */
+#define DOCK_MOD_FLAG_TX_OK 0x01u  /* the radio will key its own PTT path in this
+                                    * modulation; see the note above */
+
+/* 0x0878 status byte. The NUMBERS ARE 0x0874's, holes and all: a host that already
+ * decodes a set-VFO status reuses the same table, and "status 4 means a field was
+ * off its scale" stays true whichever command produced it. 3 (DIRECTION), 6 (BAND)
+ * and 7 (TONE) cannot arise here and are left unused rather than renumbered — holes
+ * are free, a code whose meaning depends on which opcode you were looking at is not. */
+#define DOCK_MOD_APPLIED       0u  /* on this modulation, exactly as requested   */
+#define DOCK_MOD_ERR_SHORT     1u  /* payload shorter than the parameter set     */
+#define DOCK_MOD_ERR_BUSY      2u  /* host holds full-control (0x0870)           */
+#define DOCK_MOD_ERR_FIELD     4u  /* not a modulation this firmware accepts     */
+#define DOCK_MOD_ERR_NO_HAL    5u  /* built without the radio-side binding       */
+
+/* What the radio ended up on, read back out of its own VFO after the firmware
+ * applied it — not the value that was handed in. On any rejection `modulation` and
+ * `raw` are DOCK_MOD_UNKNOWN and `flags` is 0. */
+typedef struct {
+    uint8_t status;      /* DOCK_MOD_* */
+    uint8_t modulation;  /* DOCK_MOD_*, or DOCK_MOD_UNKNOWN */
+    /* The radio's OWN ModulationMode_t value, reported for the same reason 0x0874
+     * reports OUTPUT_POWER_*: when the two scales disagree, only the raw value makes
+     * it visible. DIAGNOSTIC ONLY — its numbering moves with
+     * ENABLE_BYP_RAW_DEMODULATORS, so never branch on it. */
+    uint8_t raw;
+    uint8_t flags;       /* DOCK_MOD_FLAG_* */
+} dock_mod_applied_t;
+
+/* One repeater channel to apply.
+ *
+ * NOT a straight decode of the wire: `modulation` is carried from the session's
+ * sticky value, not from the 0x0873 payload, which has no modulation field and must
+ * not grow one (see the 0x0877 note above). Every other member is off the wire.
  *
  * `ctcss_tenths` is tenths of a Hz (1000 = 100.0 Hz), 0 for none, so the wire
  * carries the tone itself rather than an index into a table both sides would
@@ -157,6 +283,7 @@ typedef struct {
     uint8_t  direction;     /* DOCK_OFFSET_* */
     uint8_t  narrow;        /* 0 = wide FM, 1 = narrow */
     uint8_t  power;         /* 0 low, 1 mid, 2 high */
+    uint8_t  modulation;    /* DOCK_MOD_*. NOT on the wire — session sticky value */
 } dock_vfo_t;
 
 /* Thin hardware seam. Firmware binds these to BK4819_ReadRegister /
@@ -184,12 +311,26 @@ typedef struct {
      * frequencies left zero. It reports what happened; it does not re-validate
      * what dock.c already checked. */
     void     (*set_vfo)(void *user, const dock_vfo_t *vfo, dock_vfo_applied_t *out);
+    /* Optional (may be NULL — then 0x0877 answers DOCK_MOD_ERR_NO_HAL). Called on a
+     * validated 0x0877 with a wire DOCK_MOD_* value that dock.c has already range-
+     * checked. Never called while full_control is set, for the same reason set_vfo
+     * is not.
+     *
+     * MUST fill `out`: DOCK_MOD_APPLIED plus the modulation the radio is NOW on,
+     * read back out of its own VFO — not the value it was handed. It reports what
+     * happened; it does not re-validate what dock.c already checked. */
+    void     (*set_modulation)(void *user, uint8_t wire_mod, dock_mod_applied_t *out);
 } dock_hal_t;
 
 typedef struct {
     const dock_hal_t *hal;
     bool     full_control;   /* set by 0x0870, cleared by 0x0871 */
     bool     tx_on;          /* cached REG_30 TX-enable state, for edge-detect */
+    /* Session sticky modulation, DOCK_MOD_*. Applied by 0x0873 as well as 0x0877.
+     * SEEDED FROM A CONSTANT in dock_init and only ever advanced by an 0x0877 that
+     * the radio actually applied — never read back out of the radio, which would be
+     * the ADR 0132 "adopt whatever state you find" fault. See the note above. */
+    uint8_t  modulation;
     uint8_t  buf[DOCK_RX_BUF];
     uint16_t len;
 } dock_ctx_t;
@@ -214,6 +355,9 @@ void dock_send_register_info(dock_ctx_t *ctx, uint16_t reg, uint16_t value);
 
 /* Build and send the 0x0874 set-VFO reply. Exposed for the harness. */
 void dock_send_set_vfo_reply(dock_ctx_t *ctx, const dock_vfo_applied_t *r);
+
+/* Build and send the 0x0878 set-modulation reply. Exposed for the harness. */
+void dock_send_set_mod_reply(dock_ctx_t *ctx, const dock_mod_applied_t *r);
 
 /* Framing primitives (exposed for the harness). CRC-16/XMODEM. */
 uint16_t dock_crc16(const uint8_t *data, uint16_t len);

--- a/App/app/uart.c
+++ b/App/app/uart.c
@@ -667,7 +667,7 @@ static void Dock_HalSend(void *user, const uint8_t *buf, uint16_t len)
 // F5: engage/disengage the physical PA chain on a REG_30 TX-enable edge (defined
 // below, after the F3a RX helper it reuses on un-key).
 static void Dock_TxSet(void *user, bool on);
-// F6: apply a whole repeater channel to the radio's OWN VFO (0x0872, below).
+// F6: apply a whole repeater channel to the radio's OWN VFO (0x0873, below).
 static void Dock_SetVfo(void *user, const dock_vfo_t *want);
 static const dock_hal_t Dock_Hal = {
     Dock_HalRead, Dock_HalWrite, Dock_HalSend, NULL, Dock_TxSet, Dock_SetVfo
@@ -758,7 +758,7 @@ static void Dock_TxSet(void *user, bool on)
         Dock_EndTx();
 }
 
-// F6 — 0x0872 set-VFO. The one dock command that is meant to OUTLIVE the dock
+// F6 — 0x0873 set-VFO. The one dock command that is meant to OUTLIVE the dock
 // session, and the reason it has to exist:
 //
 // Everything else here writes BK4819 registers, and none of it survives. 0x0870
@@ -1087,8 +1087,8 @@ void UART_HandleCommand(uint32_t Port)
         case 0x0850:   // write BK4819 registers (no reply)
         case 0x0851:   // read BK4819 registers -> one 0x0951 reply each
         case 0x0871:   // exit full-control (clears the loop flag)
-        case 0x0872:   // set the radio's own VFO (no reply) — F6
-            // 0x0872 sits HERE, in the ordinary non-blocking dispatch, and not
+        case 0x0873:   // set the radio's own VFO (no reply) — F6
+            // 0x0873 sits HERE, in the ordinary non-blocking dispatch, and not
             // with 0x0870 below. That is the point of it: the main loop keeps
             // running, so the radio keeps sampling its own PTT pin and stays a
             // radio. Entering full-control to tune would starve the very loop

--- a/App/app/uart.c
+++ b/App/app/uart.c
@@ -681,24 +681,46 @@ static void Dock_HandleCommand(const UART_Command_t *pCmd)
     dock_dispatch(&Dock_Ctx, pCmd->Buffer, (uint16_t)(4 + pCmd->Header.Size));
 }
 
-// 0x0870 enter full-control: block here, re-entrantly servicing register R/W
-// until 0x0871 clears the flag. While blocked, the 10 ms timeslice is starved,
-// so CheckRadioInterrupts() — the only path that reprograms the BK4819 — cannot
-// run and fight us, and there is no hardware watchdog on this tree to feed
-// (both derived from the V3 tree, not assumed). VERIFY ON BENCH: the exact
-// resume-RX call on exit.
+// Bring the RX audio path fully alive for the whole full-control session.
+// radio-server reads raw audio off the AIOC continuously and gates in software,
+// so it needs audio flowing the entire time it holds full-control. But while we
+// block below, the firmware's APP_StartListening() never runs — so nothing raises
+// GPIOA8 (the external AF-amp enable, an MCU GPIO the dock CANNOT reach) or flips
+// REG_47 out of mute. Force both up-front, plus the normal RX AF/DAC gain.
+//
+// F3a proved this empirically: over the dock we forced REG_30=0xBFF1 (RX chain),
+// REG_47=0x6142 (FM/unmute) and REG_48 loud, confirmed all three by read-back —
+// yet the AIOC still read the noise floor (~109 RMS). BK4819 fully RX-alive but
+// silent ⇒ the dead gate is outside the BK4819 = GPIOA8. Only the firmware can
+// raise it. Undone on 0x0871 exit by RADIO_SetupRegisters(true), which calls
+// AUDIO_AudioPathOff() and leaves REG_47 at MUTE (bench-confirmed by the F3a
+// baseline→post-exit register diff).
+static void Dock_ForceRxAudioAlive(void)
+{
+    GPIO_EnableAudioPath();             // GPIOA8 high — the un-dockable audio-amp gate
+    gEnableSpeaker = true;
+    BK4819_SetAF(BK4819_AF_FM);         // REG_47 = 0x6142 (unmute)
+    BK4819_SetRxAudioGain();            // REG_48 — normal RX AF/DAC gain from EEPROM
+}
+
+// 0x0870 enter full-control: force RX audio alive (above), then block here,
+// re-entrantly servicing register R/W until 0x0871 clears the flag. While blocked,
+// the 10 ms timeslice is starved, so CheckRadioInterrupts() — the only path that
+// reprograms the BK4819 — cannot run and fight us, and there is no hardware
+// watchdog on this tree to feed (both derived from the V3 tree, not assumed).
 static void Dock_EnterFullControl(uint32_t Port)
 {
     Dock_EnsureInit();
     if (Dock_Ctx.full_control)
         return;                         // already inside — prevent recursion
     Dock_Ctx.full_control = true;
+    Dock_ForceRxAudioAlive();           // F3a: RX audio path was dead without this
     while (Dock_Ctx.full_control)
     {
         if (UART_IsCommandAvailable(Port))
             UART_HandleCommand(Port);   // routes 0x0850/0x0851/0x0871 to dock
     }
-    RADIO_SetupRegisters(true);         // resume normal RX (verify on bench)
+    RADIO_SetupRegisters(true);         // resume normal (muted) RX on exit
 }
 #endif // ENABLE_DOCK
 

--- a/App/app/uart.c
+++ b/App/app/uart.c
@@ -670,8 +670,12 @@ static void Dock_TxSet(void *user, bool on);
 // F6: apply a whole repeater channel to the radio's OWN VFO (0x0873, below),
 // reporting back through `out` what the radio actually ended up on (0x0874).
 static void Dock_SetVfo(void *user, const dock_vfo_t *want, dock_vfo_applied_t *out);
+// F7: put the radio on a demodulator (0x0877, below), reporting back through `out` the one it
+// actually ended up on and whether it will still key its own PTT path there (0x0878).
+static void Dock_SetModulation(void *user, uint8_t wire_mod, dock_mod_applied_t *out);
 static const dock_hal_t Dock_Hal = {
-    Dock_HalRead, Dock_HalWrite, Dock_HalSend, NULL, Dock_TxSet, Dock_SetVfo
+    Dock_HalRead, Dock_HalWrite, Dock_HalSend, NULL, Dock_TxSet, Dock_SetVfo,
+    Dock_SetModulation
 };
 static dock_ctx_t Dock_Ctx;
 static bool       Dock_Inited = false;
@@ -816,6 +820,53 @@ static const uint8_t DOCK_POWER_MAP[3] = {
     OUTPUT_POWER_LOW1, OUTPUT_POWER_MID, OUTPUT_POWER_HIGH
 };
 
+// Wire modulation -> this firmware's enum. Designated initialisers so the table reads as the
+// mapping it is, and a static assert so adding a wire value without a firmware entry fails the
+// BUILD rather than indexing off the end. Same lesson as DOCK_POWER_MAP above, applied before
+// it bites instead of after: the wire's scale and the radio's scale are not the same scale, and
+// the one time that was assumed it shipped.
+static const uint8_t DOCK_MODULATION_MAP[] = {
+    [DOCK_MOD_FM] = MODULATION_FM,
+    [DOCK_MOD_AM] = MODULATION_AM,
+};
+_Static_assert(ARRAY_SIZE(DOCK_MODULATION_MAP) == DOCK_MOD_MAX_ACCEPTED + 1u,
+               "DOCK_MODULATION_MAP must cover exactly the accepted wire values");
+
+// This firmware's enum -> the wire. A SWITCH, not an array indexed by ModulationMode_t: that
+// enum GROWS under ENABLE_BYP_RAW_DEMODULATORS (radio.h), so a lookup table would read off its
+// own end on precisely the build where the extra members exist. Anything the wire cannot name
+// is reported as DOCK_MOD_UNKNOWN rather than guessed at.
+static uint8_t Dock_ModulationToWire(ModulationMode_t m)
+{
+    switch (m) {
+    case MODULATION_FM:  return DOCK_MOD_FM;
+    case MODULATION_AM:  return DOCK_MOD_AM;
+    case MODULATION_USB: return DOCK_MOD_USB;
+    default:             return DOCK_MOD_UNKNOWN;   // BYP/RAW, or anything added later
+    }
+}
+
+// Will the radio key its OWN transmit path in this modulation? Built without
+// ENABLE_TX_WHEN_AM (this tree is not), RADIO_PrepareTX refuses anything that is not FM
+// (radio.c) — and that is the path the radio's PTT PIN drives, which is where radio-server's
+// baofeng backend keys from by asserting the AIOC's DTR line. So on that station AM stops the
+// transmitter outright. The dock's own REG_30 keying does not go through RADIO_PrepareTX and is
+// unaffected, so the same state means different things to different backends. A host cannot see
+// a build flag; this is how it finds out.
+static bool Dock_ModulationCanTx(ModulationMode_t m)
+{
+#ifdef ENABLE_TX_WHEN_AM
+    #ifdef ENABLE_BYP_RAW_DEMODULATORS
+        return m != MODULATION_BYP && m != MODULATION_RAW;   // receive-only modes
+    #else
+        UNUSED(m);
+        return true;
+    #endif
+#else
+    return m == MODULATION_FM;
+#endif
+}
+
 static void Dock_ApplyVfo(VFO_Info_t *vfo, const dock_vfo_t *want,
                           uint32_t rx10, uint32_t off10, uint8_t band,
                           const uint8_t *ctcss_idx)
@@ -847,7 +898,12 @@ static void Dock_ApplyVfo(VFO_Info_t *vfo, const dock_vfo_t *want,
     vfo->freq_config_RX.Code     = 0;
 
     vfo->CHANNEL_BANDWIDTH = want->narrow ? BANDWIDTH_NARROW : BANDWIDTH_WIDE;
-    vfo->Modulation        = MODULATION_FM;
+    // The dock session's modulation, not a literal MODULATION_FM and not whatever the radio
+    // happens to be on. Hardcoding FM here made "set AM, then tune" silently revert; adopting
+    // the radio's current value instead would tune a repeater channel in whatever the front
+    // panel was last left on (the ADR 0132 fault). dock.c seeds this FM, so a host that never
+    // sends 0x0877 gets exactly the F6 behaviour this line used to have.
+    vfo->Modulation        = DOCK_MODULATION_MAP[want->modulation];
     vfo->OUTPUT_POWER      = DOCK_POWER_MAP[want->power];   // scales differ; see the map
     vfo->Band              = band;
 
@@ -920,6 +976,47 @@ static void Dock_SetVfo(void *user, const dock_vfo_t *want, dock_vfo_applied_t *
                         ? CTCSS_Options[v->freq_config_TX.Code] : 0;
     out->power        = v->OUTPUT_POWER;   // the radio's own scale, not the wire's
     out->status       = DOCK_VFO_APPLIED;
+}
+
+// 0x0877 set-modulation. dock.c has already range-checked `wire_mod` and refused full-control,
+// so this only applies it and reports what the radio ended up on.
+//
+// WHY THE VFO AND RADIO_SetupRegisters, AND NOT RADIO_SetModulation ON ITS OWN.
+//
+// RADIO_SetModulation alone reprograms the chip and nothing else, so the change does not
+// survive: gRxVfo->Modulation still says FM, and RADIO_SetupRegisters — which a dozen unrelated
+// paths call, including the 0x0871 exit — re-derives the demodulator from it (radio.c) and puts
+// the chip straight back. That is the same "register writes do not outlive the handoff" fault
+// 0x0873 exists to escape, and the read-back below would then report FM: a lie, not a miss.
+//
+// Writing the VFO and then calling RADIO_SetModulation directly is also wrong, less obviously.
+// Its AM branch sets the AM filter bandwidth but its FM branch never restores it, so AM->FM
+// leaves the AM filter in place; and it skips the FM-gated compander, the FM-gated CTCSS
+// interrupt mask, and FUNCTION_Init's gCurrentCodeType. Half-applied, silently.
+//
+// So: write both VFOs and let the radio's own setup path do the work — the same two lines
+// Dock_SetVfo ends with, which ADR 0146 records 186 tunes through.
+static void Dock_SetModulation(void *user, uint8_t wire_mod, dock_mod_applied_t *out)
+{
+    UNUSED(user);
+
+    const ModulationMode_t mod = (ModulationMode_t)DOCK_MODULATION_MAP[wire_mod];
+
+    // BOTH VFOs, for the same reason Dock_SetVfo writes both: dual watch alternates which one
+    // is current, so setting only one leaves the demodulator up to a timer.
+    for (unsigned i = 0; i < ARRAY_SIZE(gEeprom.VfoInfo); i++)
+        gEeprom.VfoInfo[i].Modulation = mod;
+
+    RADIO_SelectVfos();
+    RADIO_SetupRegisters(true);
+
+    // Read back out of the radio's own struct, not from `mod` — if the map above were wrong,
+    // echoing the request is exactly what would hide it. This is why 0x0874 reports power.
+    const ModulationMode_t applied = gEeprom.VfoInfo[0].Modulation;
+    out->modulation = Dock_ModulationToWire(applied);
+    out->raw        = (uint8_t)applied;
+    out->flags      = Dock_ModulationCanTx(applied) ? DOCK_MOD_FLAG_TX_OK : 0u;
+    out->status     = DOCK_MOD_APPLIED;
 }
 
 // 0x0870 enter full-control: force RX audio alive (above), then block here,
@@ -1172,11 +1269,18 @@ void UART_HandleCommand(uint32_t Port)
         case 0x0851:   // read BK4819 registers -> one 0x0951 reply each
         case 0x0871:   // exit full-control (clears the loop flag)
         case 0x0873:   // set the radio's own VFO -> one 0x0874 reply — F6
-            // 0x0873 sits HERE, in the ordinary non-blocking dispatch, and not
-            // with 0x0870 below. That is the point of it: the main loop keeps
+        case 0x0877:   // set the radio's modulation -> one 0x0878 reply — F7
+            // Both sit HERE, in the ordinary non-blocking dispatch, and not with
+            // 0x0870 below. That is the point of them: the main loop keeps
             // running, so the radio keeps sampling its own PTT pin and stays a
             // radio. Entering full-control to tune would starve the very loop
             // whose output we are trying to set up.
+            //
+            // Neither arms the six-second TX lockout. gSerialConfigCountDown_500ms
+            // is set at exactly four sites in this file — CMD_0514, CMD_051B,
+            // CMD_051D and CMD_052F — and none of them is reachable from here.
+            // Keep it that way: a SETTINGS_Save* or EEPROM_WriteBuffer added to the
+            // dock path would mute the radio for six seconds on every tune.
             Dock_HandleCommand(pUART_Command);
             break;
 

--- a/App/app/uart.c
+++ b/App/app/uart.c
@@ -45,6 +45,11 @@
 #include "settings.h"
 #include "version.h"
 
+#ifdef ENABLE_DOCK
+#include "app/dock.h"
+#include "radio.h"
+#endif
+
 #if defined(ENABLE_OVERLAY)
     #include "sram-overlay.h"
 #endif
@@ -638,6 +643,65 @@ static void CMD_0602_WriteBK4819Reg(const uint8_t *pBuffer)
 }
 #endif
 
+#ifdef ENABLE_DOCK
+// radio-server "dock control mode": wire the pure app/dock.c protocol core to
+// the real BK4819 registers and UART. The port surface is deliberately tiny —
+// 0x0850/0x0851 register R/W and the 0x0870/0x0871 full-control loop — because
+// radio-server drives everything through BK4819 registers.
+static uint16_t Dock_HalRead(void *user, uint16_t reg)
+{
+    UNUSED(user);
+    return BK4819_ReadRegister((BK4819_REGISTER_t)reg);
+}
+static void Dock_HalWrite(void *user, uint16_t reg, uint16_t value)
+{
+    UNUSED(user);
+    BK4819_WriteRegister((BK4819_REGISTER_t)reg, value);
+}
+static void Dock_HalSend(void *user, const uint8_t *buf, uint16_t len)
+{
+    UNUSED(user);
+    UART_Send(buf, len);
+}
+static const dock_hal_t Dock_Hal = { Dock_HalRead, Dock_HalWrite, Dock_HalSend, NULL };
+static dock_ctx_t Dock_Ctx;
+static bool       Dock_Inited = false;
+
+static void Dock_EnsureInit(void)
+{
+    if (!Dock_Inited) { dock_init(&Dock_Ctx, &Dock_Hal); Dock_Inited = true; }
+}
+
+// Dispatch one decoded, CRC-validated top-level dock command
+// (0x0850/0x0851/0x0871). pUART_Command->Buffer holds the de-obfuscated payload
+// [ID][Size][params]; the frame size is 4 + inner Header.Size.
+static void Dock_HandleCommand(const UART_Command_t *pCmd)
+{
+    Dock_EnsureInit();
+    dock_dispatch(&Dock_Ctx, pCmd->Buffer, (uint16_t)(4 + pCmd->Header.Size));
+}
+
+// 0x0870 enter full-control: block here, re-entrantly servicing register R/W
+// until 0x0871 clears the flag. While blocked, the 10 ms timeslice is starved,
+// so CheckRadioInterrupts() — the only path that reprograms the BK4819 — cannot
+// run and fight us, and there is no hardware watchdog on this tree to feed
+// (both derived from the V3 tree, not assumed). VERIFY ON BENCH: the exact
+// resume-RX call on exit.
+static void Dock_EnterFullControl(uint32_t Port)
+{
+    Dock_EnsureInit();
+    if (Dock_Ctx.full_control)
+        return;                         // already inside — prevent recursion
+    Dock_Ctx.full_control = true;
+    while (Dock_Ctx.full_control)
+    {
+        if (UART_IsCommandAvailable(Port))
+            UART_HandleCommand(Port);   // routes 0x0850/0x0851/0x0871 to dock
+    }
+    RADIO_SetupRegisters(true);         // resume normal RX (verify on bench)
+}
+#endif // ENABLE_DOCK
+
 bool UART_IsCommandAvailable(uint32_t Port)
 {
     uint16_t Index;
@@ -856,9 +920,21 @@ void UART_HandleCommand(uint32_t Port)
         case 0x0601:
             CMD_0601_ReadBK4819Reg(Port, pUART_Command->Buffer);
             break;
-        
+
         case 0x0602:
             CMD_0602_WriteBK4819Reg(pUART_Command->Buffer);
+            break;
+#endif
+
+#ifdef ENABLE_DOCK
+        case 0x0850:   // write BK4819 registers (no reply)
+        case 0x0851:   // read BK4819 registers -> one 0x0951 reply each
+        case 0x0871:   // exit full-control (clears the loop flag)
+            Dock_HandleCommand(pUART_Command);
+            break;
+
+        case 0x0870:   // enter full-control (blocking register-servicing loop)
+            Dock_EnterFullControl(Port);
             break;
 #endif
     } // switch

--- a/App/app/uart.c
+++ b/App/app/uart.c
@@ -805,6 +805,17 @@ static bool Dock_FreqInBand(uint32_t freq10, uint8_t *band_out)
     return true;
 }
 
+// The wire's three-step power scale is NOT this firmware's OUTPUT_POWER_* enum, and assigning
+// one to the other is silently wrong in the direction that matters. This tree's enum is
+// { USER, LOW1, LOW2, LOW3, LOW4, LOW5, MID, HIGH }, so a host asking for "high" (2) was
+// getting OUTPUT_POWER_LOW2 — a level no repeater is going to hear — while "low" (0) landed on
+// OUTPUT_POWER_USER, which is not a level at all but the user-configured special case
+// (radio.c:591). LOW1 is the real bottom of the scale the radio's own power key cycles through
+// (action.c:146-147).
+static const uint8_t DOCK_POWER_MAP[3] = {
+    OUTPUT_POWER_LOW1, OUTPUT_POWER_MID, OUTPUT_POWER_HIGH
+};
+
 static void Dock_ApplyVfo(VFO_Info_t *vfo, const dock_vfo_t *want,
                           uint32_t rx10, uint32_t off10, uint8_t band,
                           const uint8_t *ctcss_idx)
@@ -837,7 +848,7 @@ static void Dock_ApplyVfo(VFO_Info_t *vfo, const dock_vfo_t *want,
 
     vfo->CHANNEL_BANDWIDTH = want->narrow ? BANDWIDTH_NARROW : BANDWIDTH_WIDE;
     vfo->Modulation        = MODULATION_FM;
-    vfo->OUTPUT_POWER      = want->power;
+    vfo->OUTPUT_POWER      = DOCK_POWER_MAP[want->power];   // scales differ; see the map
     vfo->Band              = band;
 
     RADIO_ConfigureSquelchAndOutputPower(vfo);   // TXP_CalculatedSetting, per band
@@ -907,6 +918,7 @@ static void Dock_SetVfo(void *user, const dock_vfo_t *want, dock_vfo_applied_t *
     out->tx_hz        = v->freq_config_TX.Frequency * 10u;
     out->ctcss_tenths = (v->freq_config_TX.CodeType == CODE_TYPE_CONTINUOUS_TONE)
                         ? CTCSS_Options[v->freq_config_TX.Code] : 0;
+    out->power        = v->OUTPUT_POWER;   // the radio's own scale, not the wire's
     out->status       = DOCK_VFO_APPLIED;
 }
 

--- a/App/app/uart.c
+++ b/App/app/uart.c
@@ -667,7 +667,11 @@ static void Dock_HalSend(void *user, const uint8_t *buf, uint16_t len)
 // F5: engage/disengage the physical PA chain on a REG_30 TX-enable edge (defined
 // below, after the F3a RX helper it reuses on un-key).
 static void Dock_TxSet(void *user, bool on);
-static const dock_hal_t Dock_Hal = { Dock_HalRead, Dock_HalWrite, Dock_HalSend, NULL, Dock_TxSet };
+// F6: apply a whole repeater channel to the radio's OWN VFO (0x0872, below).
+static void Dock_SetVfo(void *user, const dock_vfo_t *want);
+static const dock_hal_t Dock_Hal = {
+    Dock_HalRead, Dock_HalWrite, Dock_HalSend, NULL, Dock_TxSet, Dock_SetVfo
+};
 static dock_ctx_t Dock_Ctx;
 static bool       Dock_Inited = false;
 
@@ -752,6 +756,86 @@ static void Dock_TxSet(void *user, bool on)
         Dock_ForceTx();
     else
         Dock_EndTx();
+}
+
+// F6 — 0x0872 set-VFO. The one dock command that is meant to OUTLIVE the dock
+// session, and the reason it has to exist:
+//
+// Everything else here writes BK4819 registers, and none of it survives. 0x0870
+// backs the registers up and the exit below ends in RADIO_SetupRegisters(true),
+// which retunes the synthesiser from the radio's own VFO. So a host that tunes
+// by register can never hand this radio a channel and walk away — the moment it
+// lets go, the radio goes back to whatever its front panel said. That is why
+// radio-server's 37 repeater presets could be applied, read back correctly, and
+// still never key a machine.
+//
+// So set the VFO the radio actually transmits from, then let the firmware's own
+// chain do the work: RADIO_ApplyOffset computes the TX leg from the offset and
+// direction, and RADIO_ConfigureSquelchAndOutputPower derives the PA setting
+// from the per-band calibration in flash — the calibration the host cannot read
+// and must not invent (the mistake ADR 0128 removed). Afterwards the radio is
+// genuinely on the channel, screen and all, exactly as if a thumb had dialled it.
+
+// Resolve a CTCSS tone in tenths of a Hz against the firmware's OWN table.
+// Exact match only: "nearest" would silently transmit a tone the operator did
+// not ask for, and a repeater with a different tone simply will not open — a
+// quiet wrong answer where a refusal is recoverable.
+static bool Dock_CtcssIndex(uint16_t tenths, uint8_t *out)
+{
+    for (uint8_t i = 0; i < ARRAY_SIZE(CTCSS_Options); i++) {
+        if (CTCSS_Options[i] == tenths) { *out = i; return true; }
+    }
+    return false;
+}
+
+static void Dock_ApplyVfo(VFO_Info_t *vfo, const dock_vfo_t *want)
+{
+    // Point the RX/TX views at their own storage. Normally already true, but a
+    // VFO left in FrequencyReverse would otherwise have us fill in the leg the
+    // radio is not going to use.
+    vfo->FrequencyReverse = false;
+    vfo->pRX = &vfo->freq_config_RX;
+    vfo->pTX = &vfo->freq_config_TX;
+
+    vfo->freq_config_RX.Frequency          = want->rx_hz;
+    vfo->TX_OFFSET_FREQUENCY               = want->offset_hz;
+    vfo->TX_OFFSET_FREQUENCY_DIRECTION     = want->direction;
+    RADIO_ApplyOffset(vfo);                 // fills freq_config_TX.Frequency
+
+    // CTCSS is transmit-only, matching radio-server's preset model (rx_tone is
+    // carried but never honoured there either), so an unexpected tone on the
+    // repeater's output can never mute our receiver.
+    uint8_t idx;
+    if (want->ctcss_tenths != 0 && Dock_CtcssIndex(want->ctcss_tenths, &idx)) {
+        vfo->freq_config_TX.CodeType = CODE_TYPE_CONTINUOUS_TONE;
+        vfo->freq_config_TX.Code     = idx;
+    } else {
+        vfo->freq_config_TX.CodeType = CODE_TYPE_OFF;
+        vfo->freq_config_TX.Code     = 0;
+    }
+    vfo->freq_config_RX.CodeType = CODE_TYPE_OFF;
+    vfo->freq_config_RX.Code     = 0;
+
+    vfo->CHANNEL_BANDWIDTH = want->narrow ? BANDWIDTH_NARROW : BANDWIDTH_WIDE;
+    vfo->Modulation        = MODULATION_FM;
+    vfo->OUTPUT_POWER      = want->power;
+    vfo->Band              = FREQUENCY_GetBand(want->rx_hz);
+
+    RADIO_ConfigureSquelchAndOutputPower(vfo);   // TXP_CalculatedSetting, per band
+}
+
+static void Dock_SetVfo(void *user, const dock_vfo_t *want)
+{
+    UNUSED(user);
+    // BOTH VFOs, deliberately. gCurrentVfo follows gRxVfo/gTxVfo and dual watch
+    // alternates between them (RADIO_SelectCurrentVfo, radio.c), so setting only
+    // one leaves which frequency we transmit on up to a timer. Setting both makes
+    // the answer the same either way.
+    for (unsigned i = 0; i < ARRAY_SIZE(gEeprom.VfoInfo); i++)
+        Dock_ApplyVfo(&gEeprom.VfoInfo[i], want);
+
+    RADIO_SelectVfos();
+    RADIO_SetupRegisters(true);
 }
 
 // 0x0870 enter full-control: force RX audio alive (above), then block here,
@@ -1003,6 +1087,12 @@ void UART_HandleCommand(uint32_t Port)
         case 0x0850:   // write BK4819 registers (no reply)
         case 0x0851:   // read BK4819 registers -> one 0x0951 reply each
         case 0x0871:   // exit full-control (clears the loop flag)
+        case 0x0872:   // set the radio's own VFO (no reply) — F6
+            // 0x0872 sits HERE, in the ordinary non-blocking dispatch, and not
+            // with 0x0870 below. That is the point of it: the main loop keeps
+            // running, so the radio keeps sampling its own PTT pin and stays a
+            // radio. Entering full-control to tune would starve the very loop
+            // whose output we are trying to set up.
             Dock_HandleCommand(pUART_Command);
             break;
 

--- a/App/app/uart.c
+++ b/App/app/uart.c
@@ -47,6 +47,7 @@
 
 #ifdef ENABLE_DOCK
 #include "app/dock.h"
+#include "driver/system.h"
 #include "radio.h"
 #endif
 
@@ -663,7 +664,10 @@ static void Dock_HalSend(void *user, const uint8_t *buf, uint16_t len)
     UNUSED(user);
     UART_Send(buf, len);
 }
-static const dock_hal_t Dock_Hal = { Dock_HalRead, Dock_HalWrite, Dock_HalSend, NULL };
+// F5: engage/disengage the physical PA chain on a REG_30 TX-enable edge (defined
+// below, after the F3a RX helper it reuses on un-key).
+static void Dock_TxSet(void *user, bool on);
+static const dock_hal_t Dock_Hal = { Dock_HalRead, Dock_HalWrite, Dock_HalSend, NULL, Dock_TxSet };
 static dock_ctx_t Dock_Ctx;
 static bool       Dock_Inited = false;
 
@@ -701,6 +705,53 @@ static void Dock_ForceRxAudioAlive(void)
     gEnableSpeaker = true;
     BK4819_SetAF(BK4819_AF_FM);         // REG_47 = 0x6142 (unmute)
     BK4819_SetRxAudioGain();            // REG_48 — normal RX AF/DAC gain from EEPROM
+}
+
+// F5 — engage the physical PA on a dock-mode key. radio-server keys TX by writing
+// BK4819 REG_30 (TX_DSP), which lights the modulator but never the external PA
+// rail (REG_33 GPIO1 PA_ENABLE) or the PA bias (REG_36) — those pins are simply
+// not in radio-server's register writes, so the chip modulates and nothing
+// radiates (F4 Chain B: keyed, 0 radiated carrier; near-field chip RF only). This
+// is the TX mirror of the F3a RX force-open. dock.c detects the REG_30 TX-enable
+// edge and calls Dock_TxSet(); we add exactly the steps stock RADIO_SetTxParameters
+// (radio.c:972) does that a bare REG_30 write skips, in the same order.
+//
+// Frequency/bias come from gCurrentVfo (the boot VFO), same source stock uses.
+// In dock mode the host tunes via REG_38/39, which may differ from gCurrentVfo;
+// on the UHF bench (both radios 445.800) the band matches, and a VHF/UHF mismatch
+// would only mis-scale power, not prevent keying. ⚠ verify-on-bench: which
+// OUTPUT_POWER level dock TX radiates, and confirm the gCurrentVfo freq source.
+static void Dock_ForceTx(void)
+{
+    BK4819_ToggleGpioOut(BK4819_GPIO0_PIN28_RX_ENABLE, false);
+    BK4819_PrepareTransmit();           // REG_50/37/52 un-mute + REG_30 TX word
+    SYSTEM_DelayMs(10);
+    BK4819_PickRXFilterPathBasedOnFrequency(gCurrentVfo->pTX->Frequency);
+    BK4819_ToggleGpioOut(BK4819_GPIO1_PIN29_PA_ENABLE, true);   // the missing PA/antenna enable
+    SYSTEM_DelayMs(5);
+    BK4819_SetupPowerAmplifier(gCurrentVfo->TXP_CalculatedSetting, gCurrentVfo->pTX->Frequency);
+    SYSTEM_DelayMs(10);
+}
+
+// Drop the PA in the stock un-key order — bias to 0 (REG_36) BEFORE the PA-enable
+// GPIO (radio.c:782->784) — then restore RX: re-assert RX-enable and re-open the
+// F3a RX-audio path (PrepareTransmit's ExitBypass left REG_47 at MUTE), so the
+// receiver hears again after a service announcement.
+static void Dock_EndTx(void)
+{
+    BK4819_SetupPowerAmplifier(0, 0);
+    BK4819_ToggleGpioOut(BK4819_GPIO1_PIN29_PA_ENABLE, false);
+    BK4819_ToggleGpioOut(BK4819_GPIO0_PIN28_RX_ENABLE, true);
+    Dock_ForceRxAudioAlive();
+}
+
+static void Dock_TxSet(void *user, bool on)
+{
+    UNUSED(user);
+    if (on)
+        Dock_ForceTx();
+    else
+        Dock_EndTx();
 }
 
 // 0x0870 enter full-control: force RX audio alive (above), then block here,

--- a/App/app/uart.c
+++ b/App/app/uart.c
@@ -667,8 +667,9 @@ static void Dock_HalSend(void *user, const uint8_t *buf, uint16_t len)
 // F5: engage/disengage the physical PA chain on a REG_30 TX-enable edge (defined
 // below, after the F3a RX helper it reuses on un-key).
 static void Dock_TxSet(void *user, bool on);
-// F6: apply a whole repeater channel to the radio's OWN VFO (0x0873, below).
-static void Dock_SetVfo(void *user, const dock_vfo_t *want);
+// F6: apply a whole repeater channel to the radio's OWN VFO (0x0873, below),
+// reporting back through `out` what the radio actually ended up on (0x0874).
+static void Dock_SetVfo(void *user, const dock_vfo_t *want, dock_vfo_applied_t *out);
 static const dock_hal_t Dock_Hal = {
     Dock_HalRead, Dock_HalWrite, Dock_HalSend, NULL, Dock_TxSet, Dock_SetVfo
 };
@@ -788,7 +789,25 @@ static bool Dock_CtcssIndex(uint16_t tenths, uint8_t *out)
     return false;
 }
 
-static void Dock_ApplyVfo(VFO_Info_t *vfo, const dock_vfo_t *want)
+// Is this frequency actually inside a band this radio has, in the radio's own
+// 10 Hz units? FREQUENCY_GetBand() cannot answer that on its own: it CLAMPS,
+// returning BAND1_50MHz for anything below the bottom and BAND7_470MHz for
+// anything above the top, so it never reports a miss. Every out-of-range tune
+// therefore looks like a valid one and lands on a band whose PA calibration has
+// nothing to do with the requested frequency (radio-server ADR 0132/0134). So
+// take its answer and check the frequency really falls inside that band.
+static bool Dock_FreqInBand(uint32_t freq10, uint8_t *band_out)
+{
+    const FREQUENCY_Band_t band = FREQUENCY_GetBand(freq10);
+    if (freq10 < frequencyBandTable[band].lower || freq10 > frequencyBandTable[band].upper)
+        return false;
+    *band_out = (uint8_t)band;
+    return true;
+}
+
+static void Dock_ApplyVfo(VFO_Info_t *vfo, const dock_vfo_t *want,
+                          uint32_t rx10, uint32_t off10, uint8_t band,
+                          const uint8_t *ctcss_idx)
 {
     // Point the RX/TX views at their own storage. Normally already true, but a
     // VFO left in FrequencyReverse would otherwise have us fill in the leg the
@@ -797,18 +816,18 @@ static void Dock_ApplyVfo(VFO_Info_t *vfo, const dock_vfo_t *want)
     vfo->pRX = &vfo->freq_config_RX;
     vfo->pTX = &vfo->freq_config_TX;
 
-    vfo->freq_config_RX.Frequency          = want->rx_hz;
-    vfo->TX_OFFSET_FREQUENCY               = want->offset_hz;
+    vfo->freq_config_RX.Frequency          = rx10;
+    vfo->TX_OFFSET_FREQUENCY               = off10;
     vfo->TX_OFFSET_FREQUENCY_DIRECTION     = want->direction;
     RADIO_ApplyOffset(vfo);                 // fills freq_config_TX.Frequency
 
     // CTCSS is transmit-only, matching radio-server's preset model (rx_tone is
     // carried but never honoured there either), so an unexpected tone on the
-    // repeater's output can never mute our receiver.
-    uint8_t idx;
-    if (want->ctcss_tenths != 0 && Dock_CtcssIndex(want->ctcss_tenths, &idx)) {
+    // repeater's output can never mute our receiver. The index was resolved and
+    // any failure refused before we got here — this only writes it.
+    if (ctcss_idx != NULL) {
         vfo->freq_config_TX.CodeType = CODE_TYPE_CONTINUOUS_TONE;
-        vfo->freq_config_TX.Code     = idx;
+        vfo->freq_config_TX.Code     = *ctcss_idx;
     } else {
         vfo->freq_config_TX.CodeType = CODE_TYPE_OFF;
         vfo->freq_config_TX.Code     = 0;
@@ -819,23 +838,76 @@ static void Dock_ApplyVfo(VFO_Info_t *vfo, const dock_vfo_t *want)
     vfo->CHANNEL_BANDWIDTH = want->narrow ? BANDWIDTH_NARROW : BANDWIDTH_WIDE;
     vfo->Modulation        = MODULATION_FM;
     vfo->OUTPUT_POWER      = want->power;
-    vfo->Band              = FREQUENCY_GetBand(want->rx_hz);
+    vfo->Band              = band;
 
     RADIO_ConfigureSquelchAndOutputPower(vfo);   // TXP_CalculatedSetting, per band
 }
 
-static void Dock_SetVfo(void *user, const dock_vfo_t *want)
+static void Dock_SetVfo(void *user, const dock_vfo_t *want, dock_vfo_applied_t *out)
 {
     UNUSED(user);
+
+    // The wire carries Hz; this radio's VFO stores units of 10 Hz (see dock.h).
+    // Nothing downstream would complain about the mistake — it would just tune
+    // ten times too high, get clamped into band 7, and transmit nowhere.
+    const uint32_t rx10  = want->rx_hz / 10u;
+    const uint32_t off10 = want->offset_hz / 10u;
+
+    uint8_t band;
+    if (!Dock_FreqInBand(rx10, &band)) {
+        out->status = DOCK_VFO_ERR_BAND;
+        return;
+    }
+
+    // Validate the leg that actually radiates at least as hard as the one that
+    // only listens. Mirrors RADIO_ApplyOffset, including refusing an offset
+    // larger than the frequency rather than letting the subtraction wrap.
+    uint32_t tx10 = rx10;
+    if (want->direction == DOCK_OFFSET_ADD) {
+        tx10 = rx10 + off10;
+    } else if (want->direction == DOCK_OFFSET_SUB) {
+        if (off10 >= rx10) {
+            out->status = DOCK_VFO_ERR_BAND;
+            return;
+        }
+        tx10 = rx10 - off10;
+    }
+    uint8_t tx_band;
+    if (!Dock_FreqInBand(tx10, &tx_band)) {
+        out->status = DOCK_VFO_ERR_BAND;
+        return;
+    }
+
+    // Resolve the tone BEFORE anything is applied. Dropping an unresolvable
+    // tone and tuning anyway would leave the radio on the repeater's input
+    // transmitting no tone: the machine stays shut, and nothing anywhere says
+    // why.
+    uint8_t idx = 0;
+    const bool want_tone = (want->ctcss_tenths != 0);
+    if (want_tone && !Dock_CtcssIndex(want->ctcss_tenths, &idx)) {
+        out->status = DOCK_VFO_ERR_TONE;
+        return;
+    }
+
     // BOTH VFOs, deliberately. gCurrentVfo follows gRxVfo/gTxVfo and dual watch
     // alternates between them (RADIO_SelectCurrentVfo, radio.c), so setting only
     // one leaves which frequency we transmit on up to a timer. Setting both makes
     // the answer the same either way.
     for (unsigned i = 0; i < ARRAY_SIZE(gEeprom.VfoInfo); i++)
-        Dock_ApplyVfo(&gEeprom.VfoInfo[i], want);
+        Dock_ApplyVfo(&gEeprom.VfoInfo[i], want, rx10, off10, band,
+                      want_tone ? &idx : NULL);
 
     RADIO_SelectVfos();
     RADIO_SetupRegisters(true);
+
+    // Report the channel the radio is on, read back out of its own struct after
+    // RADIO_ApplyOffset — not the values that were asked for.
+    const VFO_Info_t *v = &gEeprom.VfoInfo[0];
+    out->rx_hz        = v->freq_config_RX.Frequency * 10u;
+    out->tx_hz        = v->freq_config_TX.Frequency * 10u;
+    out->ctcss_tenths = (v->freq_config_TX.CodeType == CODE_TYPE_CONTINUOUS_TONE)
+                        ? CTCSS_Options[v->freq_config_TX.Code] : 0;
+    out->status       = DOCK_VFO_APPLIED;
 }
 
 // 0x0870 enter full-control: force RX audio alive (above), then block here,
@@ -1087,7 +1159,7 @@ void UART_HandleCommand(uint32_t Port)
         case 0x0850:   // write BK4819 registers (no reply)
         case 0x0851:   // read BK4819 registers -> one 0x0951 reply each
         case 0x0871:   // exit full-control (clears the loop flag)
-        case 0x0873:   // set the radio's own VFO (no reply) — F6
+        case 0x0873:   // set the radio's own VFO -> one 0x0874 reply — F6
             // 0x0873 sits HERE, in the ordinary non-blocking dispatch, and not
             // with 0x0870 below. That is the point of it: the main loop keeps
             // running, so the radio keeps sampling its own PTT pin and stays a

--- a/BENCH.md
+++ b/BENCH.md
@@ -116,6 +116,41 @@ Green F2 acceptance green-lights **F3** (the full radio-server end-to-end bench 
 
 ---
 
+## F3 acceptance — the RX-audio fix (dock entry forces the audio path alive)
+
+Background (F3a live-bench diagnosis, radio-server ADR 0120): with the F2 build, RX audio to
+the AIOC read the **noise floor** whenever radio-server held full-control. Proven root cause:
+the `0x0870` blocking loop starves the firmware timeslice, so `APP_StartListening()` never
+runs — nothing raises **GPIOA8** (the external AF-amp enable, an MCU GPIO the dock protocol
+cannot reach) or unmutes `REG_47`. Over the dock we forced `REG_30=0xBFF1` + `REG_47=0x6142` +
+`REG_48` loud, **confirmed all three by read-back**, and the AIOC still read ~109 RMS — BK4819
+fully RX-alive yet silent ⇒ the gate is outside the BK4819. The fix: `Dock_EnterFullControl`
+now calls `GPIO_EnableAudioPath()` + `BK4819_SetAF(BK4819_AF_FM)` + `BK4819_SetRxAudioGain()`
+up-front, so RX audio flows the whole session. `+28 bytes` (104,144 B, 86.2%).
+
+Flash the **F3** build (`f4hwn.fusion.v5.7.0.f3-rx-audio.bin` from the `radio-server-f3-v5.7.0`
+pre-release; verify its `SHA256SUMS` first). Then, in order:
+
+1. **HT-free RX self-test (the fix working, no second radio):**
+   ```
+   uv run radio-server doctor --backend uvk5 --rx-noise
+   ```
+   It enters full-control, force-opens RX at the chip, and measures the AIOC. **Post-fix this
+   reads thousands of RMS ("LOUD")**; with the F2 build it read the floor. That jump is the fix.
+2. **Live RX:** key an HT on 445.800 → `doctor --backend uvk5 --rx-level` reads loud; browser
+   **Listen** produces audio.
+3. **Post-fix TX check (the folded F3a Phase 2):** in the browser, key PTT ~2 s and release;
+   then re-run `--rx-noise` — it must **still** read thousands. A TX/unkey cycle must not
+   re-kill RX (`_key_off` restores only `REG_30`; `REG_47`/GPIOA8 are forced at entry and
+   untouched by TX). If it goes silent, note which register `_key_off` left wrong (suspect
+   `REG_50=0x3B20`).
+4. **Resume-RX on `0x0871` exit — SETTLED by F3a data** (supersedes the F2 `⚠` item): the
+   baseline→post-exit register diff showed `RADIO_SetupRegisters(true)` re-applies
+   frequency/bandwidth and returns the radio to normal **muted idle** RX (`REG_47`→MUTE,
+   audio-path off). Radio returns to normal receive cleanly after radio-server disconnects.
+
+---
+
 ## Notes / open items
 - Once Kris confirms the five `⚠ CONFIRM AT BENCH` items, replace each placeholder with the
   real value and delete the provenance banner.

--- a/BENCH.md
+++ b/BENCH.md
@@ -14,8 +14,8 @@ The proven flash path for this fork, so every future flash follows the same step
 ## ⚠ Provenance of this document
 
 This runbook was **drafted by the F1 build cycle from the kickoff's named steps plus the
-public uvtools2/DFU procedure**. The four radio-specific specifics below are marked
-**`⚠ CONFIRM AT BENCH`**. They are **not** empirically confirmed here — the project rule is
+public uvtools2/DFU procedure**, and extended by later cycles. The radio-specific specifics below
+are marked **`⚠ CONFIRM AT BENCH`**. They are **not** empirically confirmed here — the project rule is
 that hardware facts are verified on the hardware, never asserted from memory (radio-server
 CLAUDE.md guardrail 1). Kris confirms/corrects each one on the first real flash, then this
 banner comes off.
@@ -200,8 +200,55 @@ enter and `0x0871` exit (a host crash mid-key is covered by the existing TOT, no
 
 ---
 
+## F7 — set-modulation (`0x0877`/`0x0878`)
+
+**This level has never been flashed.** Everything below is derived from reading the firmware, and
+nothing about AM on this radio has been observed. Both items stay placeholders until somebody is at
+the bench with the radio (guardrail 1) — a plausible answer written in as fact is worse than a gap,
+in a repository whose own history is four cycles of "reported success, did nothing".
+
+### 6. AM receive actually works over the AIOC  ⚠ CONFIRM AT BENCH
+
+Send `0x0877` with `modulation = 1`. Expected: `0x0878` status `0`, `modulation = 1`, `raw = 1`,
+`flags = 0`. Then confirm, in this order:
+
+1. **The radio's screen reads `AM`.** The display renders `gModulationStr[Modulation]`, so this is a
+   free visual check that the VFO field was actually written — independent of the reply.
+2. **Audio comes out.** Tune an AM signal (airband is the obvious one, 118–137 MHz — receive only)
+   and confirm `doctor --rx-noise` / `--rx-level` reads a real signal rather than the noise floor.
+   The F3a lesson applies: registers reading back correct proves nothing about audio reaching the
+   AIOC, and that cost a diagnostic cycle to learn the first time.
+3. **It survives a tune.** Send `0x0873` afterwards and confirm the screen still says `AM` — that is
+   the sticky-modulation mechanism working on real hardware rather than in the host harness.
+4. **It survives `0x0870`/`0x0871`.** Enter and leave full control; the exit's
+   `RADIO_SetupRegisters(true)` should re-derive AM from the VFO.
+
+`⚠ CONFIRM AT BENCH`: whether AM audio over the AIOC needs any gain change relative to FM. Unknown.
+Do not guess a number here.
+
+### 7. The radio refuses its own PTT in AM  ⚠ CONFIRM AT BENCH
+
+`RADIO_PrepareTX` sets `VFO_STATE_TX_DISABLE` for any non-FM modulation on a build without
+`ENABLE_TX_WHEN_AM`, which this is. `0x0878` reports that as `flags` bit 0 = 0. **Read from the
+source, not observed.**
+
+To confirm, with a **dummy load** — this is the one item here that involves keying:
+
+1. Set AM via `0x0877`; confirm `flags = 0`.
+2. Press the radio's own PTT. Expected: it refuses, and the screen shows the TX-disable state.
+3. Assert the AIOC's DTR line (the `baofeng` backend's keying path). Expected: **also refused** — it
+   drives the same pin and therefore the same `RADIO_PrepareTX` path. This is the one that matters
+   operationally, and it is the reason the flag exists.
+4. Set FM via `0x0877`; confirm `flags = 1` and that both key normally again.
+
+`⚠ CONFIRM AT BENCH`: whether a dock `0x0850` REG_30 key-up still radiates in AM. It bypasses
+`RADIO_PrepareTX` so it should, but "should" is not a measurement, and an unexpected transmission is
+exactly the class of surprise this file exists to prevent.
+
+---
+
 ## Notes / open items
-- Once Kris confirms the five `⚠ CONFIRM AT BENCH` items, replace each placeholder with the
+- Once Kris confirms the `⚠ CONFIRM AT BENCH` items, replace each placeholder with the
   real value and delete the provenance banner.
 - Record any V3-specific surprises here as they're found, so the next flash inherits them.
 - **F5 verify-on-bench:** the `OUTPUT_POWER` level and `gCurrentVfo` frequency source used for the

--- a/BENCH.md
+++ b/BENCH.md
@@ -91,6 +91,31 @@ upstream tree at the pin). That green-lights F2 (the dock-protocol port).
 
 ---
 
+## F2 acceptance — the dock control mode
+
+Flash the **F2** build (`f4hwn.fusion.v5.7.0.f2-dock.bin`, the `ENABLE_DOCK` Fusion image
+from the `radio-server-f2-v5.7.0` pre-release; verify its `SHA256SUMS` first). Then, in
+order:
+
+1. **Connect probe (the port working).** From radio-server:
+   ```
+   uv run radio-server doctor --backend uvk5
+   ```
+   The dock connect probe sends a `ReadRegisters(0x30)` (`0x0851`) and waits for a
+   `RegisterInfo` (`0x0951`) answer. **The radio answering that elicit IS the port
+   working** — doctor reports "Dock firmware alive". (A stock/no-dock build times out here.)
+2. **The four F1 gates, still true with the dock idle:** radio **boots**, **receives**,
+   **keypad works**, and behaviour is otherwise identical to plain Fusion until radio-server
+   takes control. Entering/leaving full-control (`0x0870`/`0x0871`) should return the radio
+   to normal RX on exit.
+   - `⚠ CONFIRM AT BENCH`: the exact resume-RX behaviour after `0x0871`
+     (`RADIO_SetupRegisters(true)` on loop exit) — confirm the radio returns to normal
+     receive cleanly after radio-server disconnects.
+
+Green F2 acceptance green-lights **F3** (the full radio-server end-to-end bench loop).
+
+---
+
 ## Notes / open items
 - Once Kris confirms the five `⚠ CONFIRM AT BENCH` items, replace each placeholder with the
   real value and delete the provenance banner.

--- a/BENCH.md
+++ b/BENCH.md
@@ -1,0 +1,97 @@
+# BENCH.md — flashing this firmware to a UV-K5 V3
+
+The proven flash path for this fork, so every future flash follows the same steps.
+
+> **Radio:** Quansheng **UV-K5 V3** — PY32F071 MCU, bootloader **7.00.07**.
+> The V3 is **not** the classic UV-K5 (DP32G030). It flashes over **USB DFU**, not the
+> DP32G030 serial bootloader (PTT+flashlight-on-power-up). Do not use classic-K5
+> flash procedures on this radio.
+>
+> **Tool:** `uvtools2`.
+
+---
+
+## ⚠ Provenance of this document
+
+This runbook was **drafted by the F1 build cycle from the kickoff's named steps plus the
+public uvtools2/DFU procedure**. The four radio-specific specifics below are marked
+**`⚠ CONFIRM AT BENCH`**. They are **not** empirically confirmed here — the project rule is
+that hardware facts are verified on the hardware, never asserted from memory (radio-server
+CLAUDE.md guardrail 1). Kris confirms/corrects each one on the first real flash, then this
+banner comes off.
+
+---
+
+## What you flash
+
+The `.bin` for the target edition. For the F1 build gate that is the **Fusion** build
+produced by this fork at tag `v5.7.0` / commit `3bd3ebba`, delivered as a **pre-release
+asset** on this repo (`f4hwn.fusion.<...>.bin` + `SHA256SUMS`). Verify the SHA before
+flashing:
+
+```bash
+sha256sum -c SHA256SUMS
+```
+
+For a normal release, flash the upstream `f4hwn.fusion.vX.Y.Z.bin`.
+
+---
+
+## Procedure (as performed today)
+
+### 1. DFU entry  ⚠ CONFIRM AT BENCH
+Put the V3 into USB DFU mode.
+
+- **Exact key-combo / power sequence to enter DFU:** `⟨CONFIRM: e.g. hold <key(s)> while
+  connecting USB / powering on⟩`
+- Confirm the host enumerates the DFU device (e.g. `lsusb` shows the PY32/DFU device;
+  record the **USB VID:PID** here once seen: `⟨CONFIRM VID:PID⟩`).
+- uvtools2 should detect the radio in DFU mode before you proceed.
+
+### 2. The FTDI cable  ⚠ CONFIRM AT BENCH
+- **Which cable / adapter and how it's wired:** `⟨CONFIRM: FTDI part, which pins → radio
+  jack pins, any level-shift or DTR/RTS caveat⟩`
+- **Whether the FTDI path is for flashing, for the post-flash calib dump (step 5), or
+  both:** `⟨CONFIRM⟩`
+- Note any driver/permissions step (e.g. `dialout` group, the `/dev/ttyUSB*` that appears).
+
+### 3. Flash with uvtools2
+- Open uvtools2, select the DFU-mode radio, load the verified `.bin`, write, and let it
+  verify.
+- Record the exact uvtools2 version/build used: `⟨CONFIRM uvtools2 version⟩`.
+
+### 4. The tab-conflict gotcha  ⚠ CONFIRM AT BENCH
+There is a known conflict where **`⟨CONFIRM: describe exactly what conflicts — e.g. two
+uvtools2 tabs/panels contending for the same serial port, or a second app/browser tab
+holding the port, so the flash/read fails or hangs⟩`**.
+
+- **Symptom:** `⟨CONFIRM⟩`
+- **Avoidance / fix:** `⟨CONFIRM: e.g. close the other tab / release the port / use only the
+  one panel before flashing⟩`
+
+### 5. Calibration dump — after first boot  ⚠ CONFIRM AT BENCH
+After the **first boot** on new firmware, dump the radio's calibration so it's captured
+before any further changes.
+
+- **When:** immediately after the first boot completes (radio has re-initialised on the new
+  firmware).
+- **How:** `⟨CONFIRM: exact tool + command / uvtools2 action to read the calibration region,
+  and where the dump is saved⟩`
+- **Why:** `⟨CONFIRM: e.g. so calibration can be restored if a later flash disturbs it⟩`
+- Keep the dump with the flash record for this radio.
+
+---
+
+## Acceptance (what "flashed clean" means)
+
+Radio **boots**, **receives**, and the **keypad works** — behaviour identical to the
+firmware it replaced. For the F1 gate specifically: flashing the F1-built Fusion bin over
+the release Fusion must show **no behavioural difference** (the F1 build is the unmodified
+upstream tree at the pin). That green-lights F2 (the dock-protocol port).
+
+---
+
+## Notes / open items
+- Once Kris confirms the five `⚠ CONFIRM AT BENCH` items, replace each placeholder with the
+  real value and delete the provenance banner.
+- Record any V3-specific surprises here as they're found, so the next flash inherits them.

--- a/BENCH.md
+++ b/BENCH.md
@@ -151,7 +151,58 @@ pre-release; verify its `SHA256SUMS` first). Then, in order:
 
 ---
 
+## F5 acceptance — the TX fix (dock keying now engages the PA)
+
+Background (F4 Chain B, radio-server HANDOFF + ADR 0126): with the F3 build, dock keying wrote
+BK4819 `REG_30` (TX_DSP) and the CONFIRM read-back passed, but **no RF radiated** — on an antenna
+the kv4p (an objective UHF receiver inches away) saw carrier `False` through a confirmed 5.7 s key
+(9 polls keyed-WITHOUT-RF, 0 with); on a dummy load it saw only near-field chip RF. Root cause: a
+bare `REG_30` write lights the modulator but never the **external PA rail** (`REG_33` GPIO1
+`PA_ENABLE`) or the **PA bias** (`REG_36`) — those are simply not in radio-server's register
+writes. The TX mirror of the F3a RX gap. The fix: `dock.c` edge-detects the `REG_30` TX-enable bit
+and calls `Dock_ForceTx`/`Dock_EndTx` (`uart.c`), adding exactly the PA steps stock
+`RADIO_SetTxParameters` does — `PrepareTransmit` (REG_50/37/52) → `PickRXFilterPath` →
+`ToggleGpioOut(PA_ENABLE, true)` → `SetupPowerAmplifier(TXP_CalculatedSetting, freq)` — and dropping
+them (bias→0, then PA-enable off) plus re-opening RX audio on un-key. Host protocol core untouched
+on the wire; the dock host tests go **19→31 checks**.
+
+Flash the **F5** build (`f4hwn.fusion.v5.7.0.f5-dock-force-tx.bin` from the
+`radio-server-f5-v5.7.0` pre-release; verify its `SHA256SUMS` first). **Kris present for every key;
+dummy load mandatory during iteration; antenna only for the final range proof.** Then, in order:
+
+1. **Register keying still passes (no regression):**
+   ```
+   uv run radio-server doctor --backend uvk5 --key-test        # type CONFIRM when prompted
+   ```
+   `REG_30` read-back keyed (`0xC1FE`). (A first-attempt settle flake — `0xBFF1`, retry passes —
+   was seen in F4; the F5 `SYSTEM_DelayMs` settle points target that. Note if it recurs.)
+2. **The RF now radiates — the F5 acceptance number.** Both radios on **UHF 445.800** (the kv4p is
+   UHF-only), dummy load on the UV-K5. On the server run the carrier watch, then key a tone:
+   ```
+   python3 /tmp/dual_tx_watch.py 60        # correlates UV-K5 transmitting vs kv4p carrier
+   uv run radio-server doctor --backend uvk5 --tx-tone --seconds 5 --freq 1000   # CONFIRM
+   ```
+   **PASS = kv4p carrier `True` while the UV-K5 is keyed** (`polls keyed WITH RF > 0`), where F4
+   showed 0-with / 9-without. `/tmp/kv4p_audio_probe.py 10` should show a ~1000 Hz tone in the
+   modulation.
+3. **Browser TX + a service is heard:** browser **Talk** → a second HT (or the kv4p probe) hears
+   voice; select a service (e.g. `01#` station-id) → its announcement is heard. This closes F4
+   symptoms (2) and (4).
+4. **RX survives a TX cycle:** after keying, `doctor --rx-noise` must **still** read thousands —
+   `Dock_EndTx` re-runs the F3a RX force-open, so a service announcement doesn't leave the receiver
+   deaf.
+5. **Final range proof only:** swap the dummy load for the antenna; the HT across the room now
+   hears the browser TX and the service. (⚠ verify-on-bench: which `OUTPUT_POWER` level dock TX
+   radiates — `Dock_ForceTx` uses `gCurrentVfo`'s calibrated setting.)
+
+RF guards and TOT are untouched; the PA is strictly slaved to `REG_30` and forced off at `0x0870`
+enter and `0x0871` exit (a host crash mid-key is covered by the existing TOT, not this change).
+
+---
+
 ## Notes / open items
 - Once Kris confirms the five `⚠ CONFIRM AT BENCH` items, replace each placeholder with the
   real value and delete the provenance banner.
 - Record any V3-specific surprises here as they're found, so the next flash inherits them.
+- **F5 verify-on-bench:** the `OUTPUT_POWER` level and `gCurrentVfo` frequency source used for the
+  dock-TX PA bias — see the `Dock_ForceTx` comment in `App/app/uart.c`.

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -214,6 +214,7 @@
                 "ENABLE_FEAT_F4HWN_LOGO": true,
                 "ENABLE_FEAT_F4HWN_LOGO_SAV": true,
                 "ENABLE_SWD": true,
+                "ENABLE_DOCK": true,
                 "EDITION_STRING": "Fusion",
                 "TARGET": "f4hwn.fusion"
             }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -44,7 +44,7 @@
                 "ENABLE_BYP_RAW_DEMODULATORS": false,
                 "ENABLE_BLMIN_TMP_OFF": false,
                 "ENABLE_SCAN_RANGES": true,
-                "ENABLE_EXTRA_UART_CMD": false,
+                "ENABLE_EXTRA_UART_CMD": true,
                 "ENABLE_FEAT_F4HWN": true,
                 "ENABLE_FEAT_F4HWN_GAME": false,
                 "ENABLE_FEAT_F4HWN_K5VIEWER": false,

--- a/NOTICE
+++ b/NOTICE
@@ -68,11 +68,13 @@ This fork (https://github.com/kbennett2000/uv-k1-k5v3-firmware-custom) adds a
 (https://github.com/kbennett2000/radio-server) over the existing UART, using the
 same wire protocol as nicsure's "Quansheng Dock" firmware.
 
-Where dock-mode code is derived from nicsure's Quansheng Dock firmware
-(https://github.com/nicsure/quansheng-dock-fw, app/uart.c and driver/crc.c), that
-work is licensed under the Apache License, Version 2.0 — the same license as this
-firmware — and is used with attribution to nicsure and its upstream authors, per
-the Apache-2.0 terms. Ported files carry their own modified-file notices.
+The dock-mode protocol core in App/app/dock.c is derived from nicsure's Quansheng
+Dock firmware (https://github.com/nicsure/quansheng-dock-fw, app/uart.c — the
+framing, the 16-byte XOR obfuscation table, the dummy-CRC reply, and the
+register read/write dispatch). That work is licensed under the Apache License,
+Version 2.0 — the same license as this firmware — and is used with attribution to
+nicsure and its upstream authors, per the Apache-2.0 terms. App/app/dock.c and
+App/app/dock.h carry their own modified-file notices.
 
 The nicsure "QuanshengDock" Windows client
 (https://github.com/nicsure/QuanshengDock) is licensed under the GPL-2.0 and is

--- a/NOTICE
+++ b/NOTICE
@@ -60,6 +60,25 @@ Paland, licensed under the MIT License. Its license is included at:
 
   App/external/printf/LICENSE
 
+radio-server dock control mode (kbennett2000 fork)
+--------------------------------------------------
+
+This fork (https://github.com/kbennett2000/uv-k1-k5v3-firmware-custom) adds a
+"dock control mode" so the radio can be driven by radio-server
+(https://github.com/kbennett2000/radio-server) over the existing UART, using the
+same wire protocol as nicsure's "Quansheng Dock" firmware.
+
+Where dock-mode code is derived from nicsure's Quansheng Dock firmware
+(https://github.com/nicsure/quansheng-dock-fw, app/uart.c and driver/crc.c), that
+work is licensed under the Apache License, Version 2.0 — the same license as this
+firmware — and is used with attribution to nicsure and its upstream authors, per
+the Apache-2.0 terms. Ported files carry their own modified-file notices.
+
+The nicsure "QuanshengDock" Windows client
+(https://github.com/nicsure/QuanshengDock) is licensed under the GPL-2.0 and is
+**not** copied or ported into this firmware; it is read only as a host-side
+specification of the wire protocol.
+
 License and endorsement notice
 ------------------------------
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -74,11 +74,21 @@ make it fit.
 | `0x0870` | enter full control | **none** | — |
 | `0x0871` | exit full control | **none** | — |
 | `0x0873` | set VFO | `0x0874`, **always** | 13 bytes, below |
+| `0x0877` | set modulation | `0x0878`, **always** | 1 byte, below |
 | `0x0951` | register info *(reply)* | — | `[reg:u16][value:u16]` |
 | `0x0874` | set-VFO result *(reply)* | — | 12 bytes, below |
+| `0x0878` | set-modulation result *(reply)* | — | 4 bytes, below |
 
 An unknown opcode is dropped in silence. That is the only way to detect firmware level from the
-outside: send `0x0873` and see whether anything comes back.
+outside: send `0x0873` or `0x0877` and see whether anything comes back.
+
+> **`0x0875`/`0x0876` are deliberately skipped.** radio-server's ADR 0111 records the classic
+> Quansheng Dock's full-control extras as *"0x0872 modulation, 0x0873/4 backlight, 0x0875/6 AM
+> emulation"*. That census cannot be re-verified from this tree, so it is treated as claimed rather
+> than assumed free — which is the check `0x0873`'s own allocation skipped: it was chosen after
+> ruling out `0x0872` alone, from a range the same census had already spoken for. That one is
+> shipped and cannot be walked back. If you are extending this protocol, **check the census before
+> you allocate**; a wire opcode is the one thing here you cannot rename later.
 
 ### `0x0851` read registers — and how to probe for a radio
 
@@ -181,6 +191,98 @@ values in the radio's own enum (`USER, LOW1..LOW5, MID, HIGH`) are **1, 6 and 7*
 
 ---
 
+## `0x0877` set modulation — the other extension
+
+Puts the radio on a demodulator. Like `0x0873`, it writes the radio's **own** VFO and lets the
+firmware's setup path apply it, rather than poking the chip: a chip-only change does not survive, and
+it applies only half of what a modulation change involves (the AM filter bandwidth is set on the way
+into AM and never restored on the way out; the compander and the CTCSS interrupt mask are gated on FM
+elsewhere).
+
+It writes **both** VFOs, for the same dual-watch reason `0x0873` does.
+
+### Request — 1 byte
+
+| Offset | Type | Field | Notes |
+|---|---|---|---|
+| 0 | u8 | `modulation` | `0` FM, `1` AM. `2` is **reserved for USB and refused** — see below |
+
+**The wire's values are not the firmware's enum**, on purpose. The radio's `ModulationMode_t` is
+`{ FM, AM, USB, [BYP, RAW,] UKNOWN }`, and the bracketed pair only exists on builds with
+`ENABLE_BYP_RAW_DEMODULATORS` — so the enum's numeric end **moves with a build flag**. A wire value
+derived from it would mean different things in two builds of the same protocol. Send the wire's
+numbers; the firmware maps them, both ways.
+
+`2` (USB) has its **number** fixed so it can never come to mean anything else, but the **value** is
+refused at F7 with `ERR_FIELD`. Nobody has put this radio on USB at a bench, it cannot transmit in it
+on this build anyway, and a refusal never moves the radio — so accepting it later is purely additive.
+Anything above `2` is refused as well. **Refused, never clamped.**
+
+### The modulation is sticky, and `0x0873` carries it
+
+After one successful `0x0877`, **every later `0x0873` applies that modulation too**. This is not a
+convenience. `0x0873` has to write *some* modulation into the VFO it applies; it used to write FM
+literally, so "set AM, then tune" put the radio silently back on FM. And sending the two as separate
+frames is not merely awkward — **this link drops frames**. The firmware is single-threaded and
+anything arriving while it is busy is discarded, not queued. Tune lands, set-modulation is dropped,
+and the radio sits on the right channel in the wrong demodulator with nothing on the wire saying so.
+
+Two rules follow, and both are requirements on **you**:
+
+- The sticky value is **session state, seeded FM**. It is never read back out of the radio — adopting
+  whatever the front panel was last left on is how a repeater channel ends up in the wrong
+  demodulator. A host that never sends `0x0877` gets FM on every tune, exactly as before F7.
+- It is scoped to the **radio's power cycle, not your connection**. It outlives your process. **A
+  reconnecting host must assert the modulation it wants**, not assume FM.
+
+A refused `0x0877` — busy, short, out of range — **never** moves the sticky value. Only a modulation
+the radio actually took becomes what later tunes apply.
+
+### Reply `0x0878` — 4 bytes, sent for every outcome
+
+| Offset | Type | Field |
+|---|---|---|
+| 0 | u8 | `status` |
+| 1 | u8 | `modulation` — the wire value the radio is **now** on, or `0xFF` |
+| 2 | u8 | `raw` — the radio's own `ModulationMode_t`. **Diagnostic only** |
+| 3 | u8 | `flags` — bit 0: the radio will key its own transmit path in this modulation |
+
+| `status` | Meaning |
+|---|---|
+| `0` | applied, exactly as requested |
+| `1` | payload was empty |
+| `2` | busy — the host holds full control (`0x0870`); retry after `0x0871` |
+| `4` | not a modulation this firmware accepts |
+| `5` | firmware built without the radio-side binding |
+
+The numbers are `0x0874`'s, **holes and all** — `3`, `6` and `7` cannot arise here and are left unused
+rather than renumbered, so one status table decodes both commands and "status 4 means a field was off
+its scale" stays true whichever produced it.
+
+`modulation` is read back out of the radio's VFO **after** it applied it, not echoed from the request.
+`raw` is there for the same reason `0x0874` reports the radio's own `OUTPUT_POWER_*`: when the two
+scales disagree, only the raw value makes it visible. Its numbering shifts with
+`ENABLE_BYP_RAW_DEMODULATORS`, so read it, log it, and **never branch on it**.
+
+> **On any non-zero status, `modulation` and `raw` are `0xFF` — not `0`.** `0x0874` blanks its
+> frequencies to zero because 0 Hz is obviously not a channel. Copying that here would blank
+> modulation to `0`, which **is FM** — a refusal shipping a plausible claim about where the radio is.
+> `0xFF` also means "the radio is on something this wire cannot name", which is what you get from a
+> build with the BYP/RAW demodulators compiled in.
+
+> **A successful set-AM can stop the transmitter, and that is what `flags` is for.** Built without
+> `ENABLE_TX_WHEN_AM` — which this firmware is not — the radio refuses to transmit in any modulation
+> that is not FM. That refusal lives in the path the radio's **PTT pin** drives, so if you key by
+> asserting a serial control line into that pin (an AIOC cable, say), **your transmitter stops
+> working the moment you select AM**. Keying by writing `REG_30` over `0x0850` does *not* go through
+> that path and is unaffected — so the same radio state means "cannot transmit" for one host and
+> "transmits normally" for another. You cannot see a build flag from out here; check bit 0.
+>
+> The flag **reports** the condition. It does not remove it. **AM is receive-only on this firmware**,
+> and enabling `ENABLE_TX_WHEN_AM` is not something this fork does.
+
+---
+
 ## Golden vectors
 
 Byte-exact frames, verified against both implementations. Use these before you trust your codec.
@@ -206,6 +308,35 @@ AB CD 10 00 62 64 18 E6 2E 96 C5 B2 9A 2F 5D E7 7C 19 01 83 E9 93 DC BA
 ```
 deobfuscated payload: `74 08 0C 00 00 07 C8 F2 BB 1A 88 A7 6F 1A E8 03`
 
+**`0x0877` request** — set AM (full frame):
+
+```
+AB CD 05 00 61 64 15 E6 2F 11 D5 DC BA
+```
+deobfuscated payload: `77 08 01 00 01`
+
+**its `0x0878` reply** — applied, AM, `raw = 1`, `flags = 0` (**the radio will not key its own PTT
+path in AM**):
+
+```
+AB CD 08 00 6E 64 10 E6 2E 90 0C 40 DE CA DC BA
+```
+deobfuscated payload: `78 08 04 00 00 01 01 00`
+
+**`0x0877` with an empty payload** — the F7 probe:
+
+```
+AB CD 04 00 61 64 14 E6 D7 2B DC BA
+```
+deobfuscated payload: `77 08 00 00`
+
+**its `0x0878` reply** — `ERR_SHORT`, naming no modulation:
+
+```
+AB CD 08 00 6E 64 10 E6 2F 6E F2 40 DE CA DC BA
+```
+deobfuscated payload: `78 08 04 00 01 FF FF 00`
+
 ---
 
 ## Things that are not in the protocol, and will still bite you
@@ -213,9 +344,9 @@ deobfuscated payload: `74 08 0C 00 00 07 C8 F2 BB 1A 88 A7 6F 1A E8 03`
 **A six-second transmit lockout.** The radio's *stock* EEPROM commands — the HELLO `0x0514`, the
 EEPROM read `0x051B`, the EEPROM write `0x051D`, and `0x052F` — each arm a **6-second timer during
 which the radio refuses to transmit, and cuts an over already in progress**. Reading arms it as surely
-as writing. **No dock command arms it**, which is the main practical reason to tune with `0x0873`
-rather than by writing the radio's memory. If you mix the two, expect the transmitter to be dead for
-six seconds after any memory conversation.
+as writing. **No dock command arms it** — not `0x0873` and not `0x0877` either — which is the main
+practical reason to tune with `0x0873` rather than by writing the radio's memory. If you mix the two,
+expect the transmitter to be dead for six seconds after any memory conversation.
 
 **Receive audio needs more than the chip.** The audio path to the K1 jack passes the BK4819's audio
 selector *and* an MCU GPIO that enables the external amplifier — and that GPIO is **not reachable over
@@ -229,6 +360,12 @@ transmit path also raises the power-amplifier enable and sets the PA bias. Witho
 reports a successful key-up, the register read-back confirms it, and **nothing usable radiates** — a
 near-field sniff sees a carrier and an antenna run sees nothing. This firmware performs the stock PA
 sequence on the key-up edge (that is "F5"). Diagnosing this cost a full cycle.
+
+**A non-FM modulation stops the radio's own transmit path.** Covered in full under `0x0877` above,
+repeated here because it is the kind of thing you find at a bench rather than in a spec: built without
+`ENABLE_TX_WHEN_AM`, the radio refuses to transmit in anything but FM, and that refusal is in the path
+the **PTT pin** drives. Keying by serial control line into that pin stops working the moment you
+select AM; keying by `REG_30` over `0x0850` does not. `0x0878`'s `flags` bit 0 is how you tell.
 
 **A dock transmission leaves the receiver on the wrong band.** After a dock-mode transmit, the
 firmware's filter-path selection leaves the *receive* front-end configured for the VFO's band, which
@@ -250,8 +387,9 @@ tagged `radio-server-fN-v5.7.0`.
 | **F3** | forces the receive audio path alive on `0x0870` | connects, and receives silence |
 | **F5** | engages the power amplifier on the key-up edge | keys cleanly, radiates nothing usable |
 | **F6** | `0x0873`/`0x0874` set-VFO | tuning does not survive `0x0871`; no power control |
+| **F7** | `0x0877`/`0x0878` set-modulation, and `0x0873` stops forcing FM | the radio is FM-only; there is no way to receive AM |
 
-**F6 is cumulative** — it contains F2, F3 and F5. Flash that one.
+**F7 is cumulative** — it contains F2, F3, F5 and F6. Flash that one.
 
 ### Detecting the level from your own software
 
@@ -260,11 +398,13 @@ There is no version command (the plaintext HELLO is not answered here). So ask t
 1. Prove the link with a `0x0851` read of register `0x30`. A `0x0951` back means **F2 or later**.
 2. Send a `0x0873` with an **empty** payload. A `0x0874` back — status `1`, `ERR_SHORT` — means
    **F6 or later**. Silence means older.
+3. Send a `0x0877` with an **empty** payload. A `0x0878` back — status `1`, `ERR_SHORT` — means
+   **F7 or later**. Silence means F6 or older.
 
-Step 2 is safe by construction: the length check is the first branch of that command, so the firmware
-refuses before it decodes a field, before it calls its VFO binding, and with every frequency in the
-reply blanked. It is a question, not a tune. Any `0x0874` answers it — `ERR_BUSY` proves the command
-exists just as well as `ERR_SHORT`.
+Steps 2 and 3 are safe by construction: the length check is the first branch of each command, so the
+firmware refuses before it decodes a field, before it calls its binding, and with every frequency (or
+modulation) in the reply blanked. They are questions, not commands. Any reply answers — `ERR_BUSY`
+proves the command exists just as well as `ERR_SHORT` does.
 
 ---
 
@@ -273,7 +413,7 @@ exists just as well as `ERR_SHORT`.
 - **[`App/app/dock.c`](App/app/dock.c) / [`dock.h`](App/app/dock.h)** are pure C with **no firmware or
   hardware includes** — all hardware sits behind a caller-supplied `dock_hal_t`. You can compile them
   on a host and use them as a reference decoder directly.
-- **[`tests/host/test_dock.c`](tests/host/test_dock.c)** is 66 checks including the golden frames
+- **[`tests/host/test_dock.c`](tests/host/test_dock.c)** is 98 checks including the golden frames
   above. `make -C tests/host run`. It needs nothing but a C compiler.
 - **`radio_server/backends/uvk5/frames.py`** in
   [radio-server](https://github.com/kbennett2000/radio-server) is a complete, independently-written

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1,0 +1,283 @@
+# The dock control mode — wire protocol
+
+This firmware adds a **dock control mode**: a serial protocol that lets a host computer read and write
+the radio's BK4819 chip registers, take over the radio entirely, and hand it a whole channel to tune
+itself to. It is what [radio-server](https://github.com/kbennett2000/radio-server) drives, and this
+document exists so you can drive it from **your own** software without reading that project.
+
+The framing and the register commands are byte-compatible with nicsure's
+[Quansheng Dock](https://github.com/nicsure/quansheng-dock-fw) firmware for the classic (DP32G030)
+UV-K5, from which they were ported. One command, `0x0873`, is an extension that exists only here.
+
+**Two independent implementations agree on every vector below**: this firmware's
+[`App/app/dock.c`](App/app/dock.c) and radio-server's `radio_server/backends/uvk5/frames.py`. If you
+write a third, the golden frames at the end are your oracle.
+
+---
+
+## The link
+
+**38400 baud, 8N1**, over the radio's K1 jack — in practice via an
+[AIOC cable](https://na6d.com/products/aioc-ham-radio-all-in-one-cable), which presents the radio as a
+USB serial port *and* a USB sound card on one connector.
+
+The radio **never speaks first** at top level. There is no streaming, no heartbeat, no sequence
+numbers, no flow control. Every reply is caused by a command you sent. So to find out whether a radio
+is there, you must **elicit** — send something that must be answered and see if it is. Silence means
+"no answer", never "idle".
+
+## Framing
+
+```
+ AB CD | Size:u16 LE | obf( payload[Size] + CRC:u16 LE ) | DC BA
+```
+
+- `payload = [opcode:u16 LE][param_len:u16 LE][params…]`, so `Size = 4 + param_len`.
+- Total wire length is `Size + 8`.
+- `param_len` may be 0. The payload cap is **254** bytes; a longer frame is dropped, never truncated.
+
+**Obfuscation** is a 16-byte repeating XOR, applied to the payload **and** the two CRC bytes
+(`table[i % 16]`, `i` counting from the first payload byte). It is self-inverse — the same operation
+decodes.
+
+```
+16 6C 14 E6 2E 91 0D 40 21 35 D5 40 13 03 E9 80
+```
+
+It is **always on** in this firmware. The classic dock had a plaintext `0x0514` HELLO that toggled
+encryption off; this tree hard-defines the link as encrypted and does not implement that toggle, so a
+plaintext HELLO gets no answer here. (That is a useful tell: a radio that answers a plaintext HELLO is
+on classic or stock firmware, not this one.)
+
+**CRC-16/XMODEM** — poly `0x1021`, init `0`, no reflection, no final XOR — computed over the
+**plaintext** payload.
+
+> **The asymmetry that will cost you an afternoon if you miss it.** Commands you send carry a **real
+> CRC**, and the firmware validates it and silently drops a frame that fails. Replies the radio sends
+> carry a **dummy `obf(0xFF 0xFF)`** in the CRC slot — *not* a real CRC. So **validate outgoing,
+> never validate incoming.** A decoder that checks reply CRCs rejects every reply the radio sends.
+
+### Receiving
+
+Sync on `0xAB`; require `0xCD` next; read `Size`; bounds-check `Size + 8`; wait for the whole frame;
+require the tail `0xDC 0xBA`. On any mismatch, drop one byte and resync — never truncate a frame to
+make it fit.
+
+---
+
+## Commands
+
+| Opcode | Name | Reply | Params |
+|---|---|---|---|
+| `0x0850` | write registers | **none** | `[count:u16][reg:u16, value:u16] × count` |
+| `0x0851` | read registers | `0x0951` **× count** | `[count:u16][reg:u16] × count` |
+| `0x0870` | enter full control | **none** | — |
+| `0x0871` | exit full control | **none** | — |
+| `0x0873` | set VFO | `0x0874`, **always** | 13 bytes, below |
+| `0x0951` | register info *(reply)* | — | `[reg:u16][value:u16]` |
+| `0x0874` | set-VFO result *(reply)* | — | 12 bytes, below |
+
+An unknown opcode is dropped in silence. That is the only way to detect firmware level from the
+outside: send `0x0873` and see whether anything comes back.
+
+### `0x0851` read registers — and how to probe for a radio
+
+`ReadRegisters([0x30])` is the standard liveness elicit: one register, one `0x0951` back. Retransmit
+it — opening the serial port can reset the radio, so the first attempt may be eaten by a reboot.
+
+### `0x0870` / `0x0871` full control
+
+`0x0870` takes the radio over: it clears the display, backs up the registers, forces the receive audio
+path alive, and then **sits in a loop servicing only serial commands** until `0x0871` arrives. While
+it is held:
+
+- **The radio's own logic is suspended** — that is the point, so your register writes are not fought.
+- **The PTT button and the keypad are dead.** The loop is not sampling them.
+- **The radio's own speaker hisses**, because the squelch is open at the chip. Expected; it stops on
+  exit.
+
+`0x0871` calls the firmware's `RestoreRadio()`, which ends in `RADIO_SetupRegisters(true)` — and that
+**retunes the synthesiser from the radio's own VFO**.
+
+> **Every register you wrote is thrown away on exit.** Frequency (`0x38`/`0x39`), CTCSS (`0x51`/`0x07`)
+> and bandwidth (`0x43`) are all transient. A host that tunes by register can never hand the radio a
+> channel and let go. That is precisely why `0x0873` exists.
+
+`0x0873` is deliberately dispatched **outside** the `0x0870` loop. Inside it, it answers `ERR_BUSY`.
+
+---
+
+## `0x0873` set VFO — the extension
+
+Hands the radio a whole channel and lets **its own** code set it up: `RADIO_ApplyOffset` computes the
+transmit leg, and `RADIO_ConfigureSquelchAndOutputPower` does the **per-band power-amplifier
+calibration that lives in the radio's flash and is not readable from the host**. That last point is
+why this command exists rather than a pile of register writes: the calibration is the radio's, so let
+the radio apply it.
+
+It writes **both** VFOs. Dual watch alternates which one is current, and a channel applied to only one
+of them transmits from the wrong place roughly half the time.
+
+### Request — 13 bytes
+
+| Offset | Type | Field | Notes |
+|---|---|---|---|
+| 0 | u32 LE | `rx_hz` | **Hz** |
+| 4 | u32 LE | `offset_hz` | **Hz** |
+| 8 | u16 LE | `ctcss_tenths` | tenths of a Hz: `1000` = 100.0 Hz. `0` = no tone |
+| 10 | u8 | `direction` | `0` simplex, `1` offset up, `2` offset down |
+| 11 | u8 | `narrow` | `0` wide FM, `1` narrow |
+| 12 | u8 | `power` | `0` low, `1` mid, `2` high |
+
+> **Frequencies on the wire are Hz. The radio's VFO stores 10 Hz units.** The firmware converts. Send
+> Hz. (This was wrong in the first cut and was silent, because the radio's band lookup *clamps* an
+> out-of-range value instead of rejecting it — so a frequency 10× off landed on a band edge and tuned
+> "successfully". The firmware now re-checks against the band table rather than trusting the clamp.)
+
+**Every field is validated and a bad one is refused, never clamped**, on the grounds that a channel
+silently moved is worse than a channel refused — a wrong transmit leg is somebody else's repeater.
+An offset-down that would underflow is refused rather than wrapped. A CTCSS value must match the
+radio's tone table **exactly**; a near-miss is refused rather than transmitted tone-less, because a
+tone-less transmission into a tone-guarded repeater simply does not open it and looks like a radio
+fault.
+
+### Reply `0x0874` — 12 bytes, sent for every outcome
+
+| Offset | Type | Field |
+|---|---|---|
+| 0 | u8 | `status` |
+| 1 | u8 | `power` — the **radio's** `OUTPUT_POWER_*`, not the 0/1/2 you sent |
+| 2 | u32 LE | `rx_hz` |
+| 6 | u32 LE | `tx_hz` — **the leg that actually radiates** |
+| 10 | u16 LE | `ctcss_tenths` as applied |
+
+| `status` | Meaning |
+|---|---|
+| `0` | applied, exactly as requested |
+| `1` | payload shorter than 13 bytes |
+| `2` | busy — the host holds full control (`0x0870`); retry after `0x0871` |
+| `3` | offset direction was not 0/1/2 |
+| `4` | bandwidth or power off its scale |
+| `5` | firmware built without the radio-side binding |
+| `6` | the receive or transmit leg falls outside every band this radio has |
+| `7` | tone absent from the radio's CTCSS table |
+
+**On any non-zero status the frequency fields are zeroed**, unconditionally, in the protocol core
+rather than in each binding. So a reply can never describe a channel the radio is not on, which makes
+`status` the only field you have to check first.
+
+The frequencies are read back out of the radio's VFO **after** it applied them — they are where it
+landed, not what you asked for. Compare them.
+
+### The power scale is not the scale you sent
+
+The wire's `0`/`1`/`2` maps through the firmware to `OUTPUT_POWER_LOW1`, `MID`, `HIGH`, whose numeric
+values in the radio's own enum (`USER, LOW1..LOW5, MID, HIGH`) are **1, 6 and 7**.
+
+> Assigning the wire value raw makes "high" mean `LOW2`. That tunes perfectly, reads back perfectly,
+> and **never opens a repeater** — invisible from the host until somebody notices the radio is quiet.
+> That bug shipped here and was caught only once `0x0874` started reporting the applied value. If you
+> implement this, check `power` in the reply against `{low:1, mid:6, high:7}`.
+
+---
+
+## Golden vectors
+
+Byte-exact frames, verified against both implementations. Use these before you trust your codec.
+
+**`0x0851` read register `0x30`, which holds `0xC1FE`** → the `0x0951` reply:
+
+```
+AB CD 08 00 47 65 10 E6 1E 91 F3 81 DE CA DC BA
+```
+deobfuscated payload: `51 09 04 00 30 00 FE C1`
+
+**`0x0873` request** — receive 448.525 MHz, transmit 5 MHz down, 100.0 Hz tone, wide, high power
+(params only, before framing):
+
+```
+C8 F2 BB 1A 40 4B 4C 00 E8 03 02 00 02
+```
+
+**its `0x0874` reply** — applied, `power = 7` (`HIGH`), transmit leg 443.525 MHz:
+
+```
+AB CD 10 00 62 64 18 E6 2E 96 C5 B2 9A 2F 5D E7 7C 19 01 83 E9 93 DC BA
+```
+deobfuscated payload: `74 08 0C 00 00 07 C8 F2 BB 1A 88 A7 6F 1A E8 03`
+
+---
+
+## Things that are not in the protocol, and will still bite you
+
+**A six-second transmit lockout.** The radio's *stock* EEPROM commands — the HELLO `0x0514`, the
+EEPROM read `0x051B`, the EEPROM write `0x051D`, and `0x052F` — each arm a **6-second timer during
+which the radio refuses to transmit, and cuts an over already in progress**. Reading arms it as surely
+as writing. **No dock command arms it**, which is the main practical reason to tune with `0x0873`
+rather than by writing the radio's memory. If you mix the two, expect the transmitter to be dead for
+six seconds after any memory conversation.
+
+**Receive audio needs more than the chip.** The audio path to the K1 jack passes the BK4819's audio
+selector *and* an MCU GPIO that enables the external amplifier — and that GPIO is **not reachable over
+this protocol**. Full-control mode starves the firmware timeslice that would normally raise it, so a
+host that only writes registers gets a radio that receives **silence** while every register reads back
+correct. This firmware forces the path alive on `0x0870` entry (that is what "F3" means below). On
+older builds, no amount of register writing fixes it.
+
+**Transmit needs more than `REG_30`.** Keying by writing the transmit-DSP bit is not enough: the stock
+transmit path also raises the power-amplifier enable and sets the PA bias. Without those the radio
+reports a successful key-up, the register read-back confirms it, and **nothing usable radiates** — a
+near-field sniff sees a carrier and an antenna run sees nothing. This firmware performs the stock PA
+sequence on the key-up edge (that is "F5"). Diagnosing this cost a full cycle.
+
+**A dock transmission leaves the receiver on the wrong band.** After a dock-mode transmit, the
+firmware's filter-path selection leaves the *receive* front-end configured for the VFO's band, which
+may not be the band you transmitted on. That is **not fixed in firmware** — radio-server corrects it
+host-side. If you tune far from where the radio's own VFO sits, expect to re-assert your receive
+registers after every over.
+
+---
+
+## Firmware levels
+
+The dock mode arrived in stages, and each unlocked something the one before it lacked. Releases are
+tagged `radio-server-fN-v5.7.0`.
+
+| Level | Adds | Without it |
+|---|---|---|
+| **F1** | nothing — a build gate proving fork → build → flash → boot on an unmodified image | — |
+| **F2** | the dock mode itself: `0x0850`/`0x0851`/`0x0870`/`0x0871` | no dock at all; the commands are silently ignored |
+| **F3** | forces the receive audio path alive on `0x0870` | connects, and receives silence |
+| **F5** | engages the power amplifier on the key-up edge | keys cleanly, radiates nothing usable |
+| **F6** | `0x0873`/`0x0874` set-VFO | tuning does not survive `0x0871`; no power control |
+
+**F6 is cumulative** — it contains F2, F3 and F5. Flash that one.
+
+### Detecting the level from your own software
+
+There is no version command (the plaintext HELLO is not answered here). So ask the *command*:
+
+1. Prove the link with a `0x0851` read of register `0x30`. A `0x0951` back means **F2 or later**.
+2. Send a `0x0873` with an **empty** payload. A `0x0874` back — status `1`, `ERR_SHORT` — means
+   **F6 or later**. Silence means older.
+
+Step 2 is safe by construction: the length check is the first branch of that command, so the firmware
+refuses before it decodes a field, before it calls its VFO binding, and with every frequency in the
+reply blanked. It is a question, not a tune. Any `0x0874` answers it — `ERR_BUSY` proves the command
+exists just as well as `ERR_SHORT`.
+
+---
+
+## Implementing against this
+
+- **[`App/app/dock.c`](App/app/dock.c) / [`dock.h`](App/app/dock.h)** are pure C with **no firmware or
+  hardware includes** — all hardware sits behind a caller-supplied `dock_hal_t`. You can compile them
+  on a host and use them as a reference decoder directly.
+- **[`tests/host/test_dock.c`](tests/host/test_dock.c)** is 66 checks including the golden frames
+  above. `make -C tests/host run`. It needs nothing but a C compiler.
+- **`radio_server/backends/uvk5/frames.py`** in
+  [radio-server](https://github.com/kbennett2000/radio-server) is a complete, independently-written
+  Python implementation of this protocol, with the register-level cookbook (frequency, bandwidth,
+  CTCSS, key-up/key-down) in its `radio.py`.
+- The BK4819 register sequences for tuning and keying are **not** part of this protocol — they are the
+  chip's, reachable through `0x0850`/`0x0851`. See radio-server's ADR 0112 for the derived sequences.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,104 @@
+# F4HWN + a dock control mode, for the UV-K1 / UV-K5 V3
+
+**This fork adds one thing to [F4HWN](https://github.com/armel/uv-k1-k5v3-firmware-custom): a *dock
+control mode* — a serial protocol that lets a computer tune, configure and key the radio over the K1
+jack.** Everything else here is F4HWN's, unchanged; its own documentation follows below and is still
+the reference for the firmware's features and menus.
+
+- **Base:** [`armel/uv-k1-k5v3-firmware-custom`](https://github.com/armel/uv-k1-k5v3-firmware-custom),
+  tag **`v5.7.0`** (commit `3bd3ebb`), Apache-2.0. The **Fusion** edition.
+- **Radio:** UV-K1 / UV-K5 **V3** — the **PY32F071** MCU. It will not run on a classic UV-K5 (DP32G030),
+  and firmware built for that chip will not run here.
+- **Protocol:** **[PROTOCOL.md](PROTOCOL.md)** — the full wire spec, with golden test vectors.
+- **Flashing:** [BENCH.md](BENCH.md).
+
+## Why
+
+Nothing open-source let a computer *drive* a UV-K5 V3. nicsure's
+[Quansheng Dock](https://github.com/nicsure/quansheng-dock-fw) does exactly that for the **classic**
+UV-K5, but it targets the DP32G030 and cannot run on a V3 at all. The V3 keeps the same **BK4819** RF
+chip, so the protocol ports cleanly — what was missing was somebody doing it.
+
+The dock command surface here is deliberately **byte-compatible** with the classic Dock, so a host
+program written for one drives the other. It was built for
+[radio-server](https://github.com/kbennett2000/radio-server), which controls a ham station over HTTP,
+but it has no dependency on it — the protocol is documented and the reference decoder is plain C.
+
+## What it adds
+
+Five commands and two replies (see [PROTOCOL.md](PROTOCOL.md) for the byte layouts):
+
+| | |
+|---|---|
+| `0x0850` / `0x0851` → `0x0951` | read and write BK4819 chip registers |
+| `0x0870` / `0x0871` | enter and leave full control — the radio's own logic stands down |
+| `0x0873` → `0x0874` | **hand the radio a whole channel** and let its own code apply it |
+
+`0x0873` is the one command with no classic-Dock equivalent, and it exists because of a trap:
+`0x0871` ends in `RADIO_SetupRegisters()`, which retunes the synthesiser from the radio's own VFO — so
+**every register a host writes is discarded when it lets go**. `0x0873` writes the radio's VFO
+instead, then lets the firmware run its own `RADIO_ApplyOffset` and, critically, its own per-band
+power-amplifier calibration, which lives in flash the host cannot read.
+
+**What it does not touch:** no keypress simulation, no screen capture, no scan or GPIO commands, no
+modulation control. `App/app/dock.c` and `dock.h` are new; four existing files gained a dispatch case,
+a HAL binding, a build flag. Nothing in the radio's own operation changes until a host sends `0x0870`.
+
+## Firmware levels
+
+Each cycle unlocked something the one before it lacked. Releases are tagged `radio-server-fN-v5.7.0`.
+
+| Level | Adds | Symptom without it |
+|---|---|---|
+| **F1** | nothing — a build gate proving fork → build → flash → boot on an unmodified image | — |
+| **F2** | the dock mode itself | the commands are silently ignored |
+| **F3** | forces the receive audio path alive on `0x0870` entry | dock connects and receives **silence**, with every register reading back correct |
+| **F5** | engages the power amplifier on the key-up edge | keys cleanly and **radiates nothing usable** |
+| **F6** | `0x0873`/`0x0874` set-VFO | tuning does not survive `0x0871`; no transmit-power control |
+
+**[Flash F6](../../releases/tag/radio-server-f6-v5.7.0).** It is cumulative. F3 and F5 are the two
+that cost a diagnostic cycle each to find, and neither is visible from the host as a fault — the radio
+reports success and does nothing. If you are debugging a silent radio, check the level first.
+
+## Build
+
+```sh
+./compile-with-docker.sh Fusion      # -> build/Fusion/f4hwn.fusion.bin
+```
+
+Docker + CMake + ARM GNU Toolchain 13.3; the script builds the image on first run. **Headless?** The
+script passes `docker run -it`, which needs a TTY — without one, run it directly:
+
+```sh
+docker build -t uvk1-uvk5v3 .
+docker run --rm -u $(id -u):$(id -g) -v "$PWD":/src -w /src uvk1-uvk5v3 \
+  bash -c "cmake --preset Fusion && cmake --build --preset Fusion -j"
+```
+
+The dock mode is behind `ENABLE_DOCK`, on in the Fusion preset. Flash region is 118 KB and the dock
+costs about 1 KB of it.
+
+## Test
+
+```sh
+make -C tests/host run      # 66 checks, needs only a C compiler
+```
+
+`App/app/dock.c` is pure C with no firmware or hardware includes — all hardware sits behind a
+caller-supplied `dock_hal_t` — so the whole protocol core compiles and runs on a development machine.
+That is also what makes it usable as a reference decoder in your own project. The tests include
+byte-exact golden frames, cross-checked against an independent Python implementation.
+
+## Licence and credit
+
+Apache-2.0, carrying forward DualTachyon's original copyright and F4HWN's work. The dock port derives
+from nicsure's Apache-2.0 `quansheng-dock-fw`; its GPL-2.0 Windows client was read as a specification
+and **not** copied. See [NOTICE](NOTICE).
+
+Per F4HWN's request below: this fork is open source and will stay that way.
+
+---
+
 # Stats
 
 ![Alt](https://repobeats.axiom.co/api/embed/ecdd86aa536b716f088339a0c5ee734558f78c28.svg "Repobeats analytics image")

--- a/README.md
+++ b/README.md
@@ -28,23 +28,30 @@ but it has no dependency on it — the protocol is documented and the reference 
 
 ## What it adds
 
-Five commands and two replies (see [PROTOCOL.md](PROTOCOL.md) for the byte layouts):
+Six commands and three replies (see [PROTOCOL.md](PROTOCOL.md) for the byte layouts):
 
 | | |
 |---|---|
 | `0x0850` / `0x0851` → `0x0951` | read and write BK4819 chip registers |
 | `0x0870` / `0x0871` | enter and leave full control — the radio's own logic stands down |
 | `0x0873` → `0x0874` | **hand the radio a whole channel** and let its own code apply it |
+| `0x0877` → `0x0878` | **put the radio on a demodulator** (FM or AM), the same way |
 
-`0x0873` is the one command with no classic-Dock equivalent, and it exists because of a trap:
-`0x0871` ends in `RADIO_SetupRegisters()`, which retunes the synthesiser from the radio's own VFO — so
-**every register a host writes is discarded when it lets go**. `0x0873` writes the radio's VFO
-instead, then lets the firmware run its own `RADIO_ApplyOffset` and, critically, its own per-band
-power-amplifier calibration, which lives in flash the host cannot read.
+`0x0873` and `0x0877` have no classic-Dock equivalent, and they exist because of a trap: `0x0871`
+ends in `RADIO_SetupRegisters()`, which retunes the synthesiser from the radio's own VFO — so **every
+register a host writes is discarded when it lets go**. They write the radio's VFO instead, then let
+the firmware run its own `RADIO_ApplyOffset` and, critically, its own per-band power-amplifier
+calibration, which lives in flash the host cannot read.
 
-**What it does not touch:** no keypress simulation, no screen capture, no scan or GPIO commands, no
-modulation control. `App/app/dock.c` and `dock.h` are new; four existing files gained a dispatch case,
-a HAL binding, a build flag. Nothing in the radio's own operation changes until a host sends `0x0870`.
+The modulation is **sticky for the session**, so a later `0x0873` keeps it rather than silently
+forcing FM. That matters because the link drops frames: sending "tune" and "set modulation" as two
+independent commands can leave the radio on the right channel in the wrong demodulator, and say
+nothing. **AM is receive-only** — the radio refuses to transmit in it, and `0x0878` reports that as a
+flag rather than leaving a host to discover it with a dead transmitter.
+
+**What it does not touch:** no keypress simulation, no screen capture, no scan or GPIO commands.
+`App/app/dock.c` and `dock.h` are new; four existing files gained a dispatch case, a HAL binding, a
+build flag. Nothing in the radio's own operation changes until a host sends a dock command.
 
 ## Firmware levels
 
@@ -57,8 +64,9 @@ Each cycle unlocked something the one before it lacked. Releases are tagged `rad
 | **F3** | forces the receive audio path alive on `0x0870` entry | dock connects and receives **silence**, with every register reading back correct |
 | **F5** | engages the power amplifier on the key-up edge | keys cleanly and **radiates nothing usable** |
 | **F6** | `0x0873`/`0x0874` set-VFO | tuning does not survive `0x0871`; no transmit-power control |
+| **F7** | `0x0877`/`0x0878` set-modulation; `0x0873` stops forcing FM | the radio is FM-only — there is no way to receive AM |
 
-**[Flash F6](../../releases/tag/radio-server-f6-v5.7.0).** It is cumulative. F3 and F5 are the two
+**[Flash F7](../../releases/tag/radio-server-f7-v5.7.0).** It is cumulative. F3 and F5 are the two
 that cost a diagnostic cycle each to find, and neither is visible from the host as a fault — the radio
 reports success and does nothing. If you are debugging a silent radio, check the level first.
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ the reference for the firmware's features and menus.
   and firmware built for that chip will not run here.
 - **Protocol:** **[PROTOCOL.md](PROTOCOL.md)** — the full wire spec, with golden test vectors.
 - **Flashing:** [BENCH.md](BENCH.md).
+- **Contributing / working on the dock code:** [AGENTS.md](AGENTS.md) — build, test, the
+  byte-compatibility contract, and the guardrails.
 
 ## Why
 

--- a/adr/0001-dock-force-tx.md
+++ b/adr/0001-dock-force-tx.md
@@ -1,0 +1,109 @@
+# 0001 — Dock mode: engage the PA on key-up (`Dock_ForceTx`, F5)
+
+Status: Accepted
+
+> First ADR in this fork. Prior cycles (F1 build gate, F2 dock port, F3a RX force-open) are
+> recorded in radio-server's `docs/adr/` (0118 / 0119 / 0120) and this repo's `BENCH.md`. F5 adds
+> an ADR here because the change is a self-contained firmware decision; radio-server's companion
+> ADR **0126** closes its "Chain B" from the host side.
+
+## Context
+
+radio-server drives this radio as a "dock": it holds full-control and does everything through
+BK4819 register reads/writes over the UART protocol in `App/app/dock.c`. It keys TX by writing
+`REG_30` (the TX-enable word `0xC1FE`) and confirms with a read-back (`0xC1FE`).
+
+F4 Chain B (radio-server bench) proved that keying **produces no radiated RF**: with an antenna,
+an objective UHF receiver (a kv4p, inches away) saw carrier `False` through a confirmed 5.7 s key
+(9 polls keyed-WITHOUT-RF, 0 with); on a dummy load it saw only near-field chip RF. The modulator
+keys; nothing reaches the antenna.
+
+### Root cause — a bare `REG_30` write skips the PA chain
+
+Stock TX (`FUNCTION_Transmit` → `RADIO_SetTxParameters`, `App/radio.c:972`) does far more than
+write `REG_30`. Register-by-register, a bare `REG_30=0xC1FE` write **omits**:
+
+- **`REG_33` GPIO1 `PA_ENABLE`** (`BK4819_ToggleGpioOut(BK4819_GPIO1_PIN29_PA_ENABLE, true)`,
+  `radio.c:1017`) — the external PA rail / antenna-switch enable. **The primary missing step.**
+- **`REG_36` PA bias** (`BK4819_SetupPowerAmplifier(TXP_CalculatedSetting, freq)`, `radio.c:1021`)
+  — the calibrated analog PA drive.
+- **`REG_50`/`REG_37`/`REG_52`** un-mute (`BK4819_PrepareTransmit`, `bk4819.c:1166`).
+- dropping `REG_33` GPIO0 `RX_ENABLE` and setting the LNA/RF-filter path GPIOs.
+
+**Correction to the F4 framing.** The radio-server HANDOFF called these "MCU-side GPIOs," by
+analogy to the F3a RX gap where `GPIOA8` (an MCU pin) was genuinely un-dockable. That is not the
+case here: on this **PY32F071 port there are no MCU GPIOs in the TX path** — PA-enable, the T/R
+switch, and the LNAs are all **internal BK4819 GPIOs written through `REG_33`**, and PA bias is
+`REG_36`. Both are BK4819 registers reachable over the dock in principle; radio-server simply never
+writes them. The mechanism (no PA) stands; the "un-dockable" label was imprecise.
+
+## Decision — slave the PA to `REG_30`: decode in the core, drive in the glue
+
+**1. Core (`App/app/dock.c` + `dock.h`) — a per-write TX-state seam.** `dock_hal_t` gains one
+optional `tx_set(user, on)` callback and `dock_ctx_t` a cached `tx_on`. In the `WRITE_REGS`
+dispatch, a write to `REG_30` edge-detects `ENABLE_TX_DSP` (bit 1: set in `0xC1FE`, clear in the
+RX word `0xBFF1`) and calls `tx_set(on)` **before** completing the register write. `tx_set(false)`
+is also forced at `0x0870` enter and `0x0871` exit (fail-safe against a stale key). Edge-detected,
+so repeat writes and redundant force-offs never re-fire. This adds **zero wire bytes** — no new
+opcodes, no replies on writes — so radio-server's `FirmwareFakeSerial`/`Uvk5Decoder` byte-compat
+and the whole F2 invariant hold; `dock_hal_t` is internal firmware state the host never sees.
+
+**2. Glue (`App/app/uart.c`) — `Dock_ForceTx` / `Dock_EndTx`, bound to `tx_set`.** These add
+exactly the stock PA steps, reusing the firmware's own helpers (not raw pokes):
+
+```c
+// key: add what a bare REG_30 write skips, in stock order
+BK4819_ToggleGpioOut(RX_ENABLE, false);
+BK4819_PrepareTransmit();                 // REG_50/37/52
+SYSTEM_DelayMs(10);
+BK4819_PickRXFilterPathBasedOnFrequency(freq);
+BK4819_ToggleGpioOut(PA_ENABLE, true);    // the missing rail
+SYSTEM_DelayMs(5);
+BK4819_SetupPowerAmplifier(TXP_CalculatedSetting, freq);   // REG_36 bias
+SYSTEM_DelayMs(10);
+
+// un-key: stock order — bias to 0 BEFORE the rail (radio.c:782->784), then restore RX
+BK4819_SetupPowerAmplifier(0, 0);
+BK4819_ToggleGpioOut(PA_ENABLE, false);
+BK4819_ToggleGpioOut(RX_ENABLE, true);
+Dock_ForceRxAudioAlive();                 // PrepareTransmit muted REG_47 — re-open RX audio
+```
+
+The `SYSTEM_DelayMs` settle points mirror stock and target the F4 first-key settle flake
+(`REG_30=0xBFF1` on the first key, retry passes). `Dock_EndTx` re-runs the F3a RX force-open so a
+service announcement (a TX cycle) does not leave the receiver deaf.
+
+**Why not call `RADIO_SetTxParameters()` wholesale?** It re-tunes from `gCurrentVfo->pTX->Frequency`
+(`radio.c:1006`), which in dock mode may differ from the frequency the host tuned via `REG_38/39` —
+it would fight the dock-tuned frequency. The surgical path leaves `REG_30` and frequency to the
+host and only adds the missing PA chain.
+
+## Consequences
+
+- **radio-server is byte-identical.** The fix is entirely in the fork; no `frames.py`/`transport.py`/
+  backend change. Its only radio-server deliverable is docs ADR 0126.
+- **Host tests: 19 → 31 checks** (`tests/host/`), all green under `-Wall -Wextra -Werror`. The new
+  cases prove the state machine: key/un-key edges fire `tx_set` before the register write (`"1w"` /
+  `"1w0w"` ordering), edge-detect suppresses repeats (`"1www"`), non-`REG_30` writes never key, and
+  `0x0870`/`0x0871` force the PA off. The PA-driving itself (`uart.c`) is bench-verified, not
+  host-compiled.
+- **Fail-safe.** PA strictly slaved to `REG_30`, forced off at enter/exit. A host crash mid-key is
+  covered by the existing TOT/RF-guards (untouched) — not by this change. (The `dock_rx_byte`
+  buffer-overflow guard is unreachable for valid frames, `DOCK_RX_BUF 264 > max total 262`, and the
+  firmware uses the top-level UART deframer, not `dock_consume`; no force-off was added there.)
+
+## Verify-on-bench (marked, not asserted)
+
+- Which `OUTPUT_POWER` level dock TX radiates, and confirming the `gCurrentVfo` frequency source for
+  the PA bias (`Dock_ForceTx` comment). On the UHF bench (both radios 445.800) the band matches; a
+  VHF/UHF mismatch would only mis-scale power, not prevent keying.
+- The staged bench acceptance (dummy load → `--key-test` → carrier watch shows RF where F4 showed
+  none → browser TX + service → antenna range proof) is in `BENCH.md` (F5 section).
+
+## Source of truth
+
+Fork `kbennett2000/uv-k1-k5v3-firmware-custom`, branch `f5-dock-force-tx`, based on the
+`f3-rx-audio-fix` tip `79f9b21` (same pin v5.7.0 / `3bd3ebba`, Apache-2.0). Symbols reused, all
+pre-existing: `BK4819_ToggleGpioOut`/`BK4819_SetupPowerAmplifier`/`BK4819_PrepareTransmit`/
+`BK4819_PickRXFilterPathBasedOnFrequency` (`App/driver/bk4819.h`), `gCurrentVfo.TXP_CalculatedSetting`
+(`App/radio.h`), `Dock_ForceRxAudioAlive` (F3a, `App/app/uart.c`).

--- a/adr/0001-dock-force-tx.md
+++ b/adr/0001-dock-force-tx.md
@@ -92,11 +92,27 @@ host and only adds the missing PA chain.
   buffer-overflow guard is unreachable for valid frames, `DOCK_RX_BUF 264 > max total 262`, and the
   firmware uses the top-level UART deframer, not `dock_consume`; no force-off was added there.)
 
-## Verify-on-bench (marked, not asserted)
+## Verify-on-bench — ANSWERED 2026-07-25 (radio-server ADR 0132)
 
-- Which `OUTPUT_POWER` level dock TX radiates, and confirming the `gCurrentVfo` frequency source for
-  the PA bias (`Dock_ForceTx` comment). On the UHF bench (both radios 445.800) the band matches; a
-  VHF/UHF mismatch would only mis-scale power, not prevent keying.
+Both marked items are now measured, by reading the registers back over the dock while keyed. One
+was confirmed; the other was **wrong in a way that mattered**.
+
+- **Which `OUTPUT_POWER` level dock TX radiates: PA bias 12** (`0x36 = 0x0CA2` keyed on 445.800).
+  A low setting; enough for the bench. The lever for more is the radio's own OUTPUT_POWER, since
+  `TXP_CalculatedSetting` is derived from it and from per-band calibration in SPI flash.
+- **The `gCurrentVfo` frequency source is confirmed — and the guess about its consequence was
+  wrong.** "A VHF/UHF mismatch would only mis-scale power, not prevent keying" is true about
+  keying and misses the receiver entirely. Keyed on 147.555 with the radio's VFO on UHF, measured:
+  reg `0x36 = 0x0CA2` (UHF gain byte on a 2 m carrier) and reg `0x33` with the **UHF LNA path**
+  selected — and `Dock_EndTx` does not put the LNA back. `PickRXFilterPathBasedOnFrequency` writes
+  the *receive* front-end, so every transmission left the receiver pointing at the wrong band, and
+  nothing on the host re-steered it. The station went deaf after its first over.
+
+  radio-server now corrects both registers from the host **after** `Dock_ForceTx` completes, which
+  needs no firmware change. The clean fix here would be for `Dock_ForceTx` to derive its band from
+  a `REG_38/39` read-back instead of `gCurrentVfo` (call it F6) — worth doing if this fork is
+  rebuilt for another reason, but it is not required: it costs a flash, and a flash costs holding
+  a key at power-on.
 - The staged bench acceptance (dummy load → `--key-test` → carrier watch shows RF where F4 showed
   none → browser TX + service → antenna range proof) is in `BENCH.md` (F5 section).
 

--- a/tests/host/.gitignore
+++ b/tests/host/.gitignore
@@ -1,0 +1,1 @@
+test_dock

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -1,0 +1,21 @@
+# Host-side tests for the dock protocol core (App/app/dock.c).
+# Pure C, no firmware/hardware dependencies — builds and runs on the host.
+#
+#   make -C tests/host run
+
+CC      ?= cc
+CFLAGS  ?= -std=c11 -Wall -Wextra -Werror -O2
+INCLUDES = -I../../App
+
+SRC = test_dock.c ../../App/app/dock.c
+
+test_dock: $(SRC) ../../App/app/dock.h
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $(SRC)
+
+run: test_dock
+	./test_dock
+
+clean:
+	rm -f test_dock
+
+.PHONY: run clean

--- a/tests/host/test_dock.c
+++ b/tests/host/test_dock.c
@@ -89,14 +89,21 @@ static void hal_set_vfo(void *u, const dock_vfo_t *vfo, dock_vfo_applied_t *out)
         out->rx_hz        = 0xDEADBEEFu;
         out->tx_hz        = 0xFEEDFACEu;
         out->ctcss_tenths = 0x1234u;
+        out->power        = 0x7Fu;
         return;
     }
+    /* Mirrors uart.c's DOCK_POWER_MAP. The wire's 0/1/2 are NOT the firmware's
+     * OUTPUT_POWER_* values (that enum is USER, LOW1..LOW5, MID, HIGH), and
+     * dock.c must pass whatever the binding reports straight through rather
+     * than assuming the two scales agree. */
+    static const uint8_t FAKE_POWER_MAP[3] = { 1u, 6u, 7u };   /* LOW1, MID, HIGH */
     out->status       = DOCK_VFO_APPLIED;
     out->rx_hz        = vfo->rx_hz;
     out->tx_hz        = (vfo->direction == DOCK_OFFSET_ADD) ? vfo->rx_hz + vfo->offset_hz
                       : (vfo->direction == DOCK_OFFSET_SUB) ? vfo->rx_hz - vfo->offset_hz
                       : vfo->rx_hz;
     out->ctcss_tenths = vfo->ctcss_tenths;
+    out->power        = FAKE_POWER_MAP[vfo->power];
 }
 static const dock_hal_t HAL = { hal_read, hal_write, hal_send, NULL, hal_tx, hal_set_vfo };
 /* A build with no radio-side binding at all — 0x0873 must still answer. */
@@ -115,6 +122,7 @@ static bool last_vfo_reply(dock_vfo_applied_t *out)
     if ((uint16_t)(body[0] | (body[1] << 8)) != DOCK_REPLY_SET_VFO) return false;
     if ((uint16_t)(body[2] | (body[3] << 8)) != 12u) return false;
     out->status = body[4];
+    out->power  = body[5];
     out->rx_hz  = (uint32_t)body[6]  | ((uint32_t)body[7] << 8)
                 | ((uint32_t)body[8] << 16) | ((uint32_t)body[9] << 24);
     out->tx_hz  = (uint32_t)body[10] | ((uint32_t)body[11] << 8)
@@ -413,19 +421,34 @@ int main(void)
     CHECK(rep.rx_hz == 448525000u && rep.tx_hz == 443525000u,
           "0x0874: reports BOTH legs, so the caller learns where it will radiate");
     CHECK(rep.ctcss_tenths == 1000u, "0x0874: reports the tone actually set");
+    CHECK(rep.power == 7u,
+          "0x0874: reports the RADIO's power level, not the 0/1/2 that was sent");
 
     /* 17b. Byte-exact reply vector — an oracle independent of this file's own
      *      builders, and the thing radio-server's decoder is written against. */
     {
         static const uint8_t golden[] = {
             0xAB, 0xCD, 0x10, 0x00, 0x62, 0x64, 0x18, 0xE6,
-            0x2E, 0x91, 0xC5, 0xB2, 0x9A, 0x2F, 0x5D, 0xE7,
+            0x2E, 0x96, 0xC5, 0xB2, 0x9A, 0x2F, 0x5D, 0xE7,
             0x7C, 0x19, 0x01, 0x83, 0xE9, 0x93, 0xDC, 0xBA,
         };
         CHECK(g_caplen == sizeof(golden), "0x0874: golden reply length");
         CHECK(g_caplen == sizeof(golden) &&
               memcmp(g_cap, golden, sizeof(golden)) == 0, "0x0874: byte-exact reply");
     }
+
+    /* 17c. The power byte is a conduit, not a copy of the request: asking for
+     *      mid (1) must come back as the radio's own MID, not as 1. */
+    reset();
+    {
+        uint8_t v[DOCK_SET_VFO_PARAM_LEN];
+        memcpy(v, K0PRA, sizeof(v));
+        v[12] = 1;                                 /* wire "mid" */
+        flen = build_cmd(frame, DOCK_CMD_SET_VFO, v, sizeof(v));
+        feed(frame, flen);
+    }
+    CHECK(last_vfo_reply(&rep) && rep.power == 6u,
+          "0x0874: the wire's mid maps onto the radio's own scale, and is reported as such");
 
     /* 18. A simplex channel is expressible: no offset, no tone. */
     reset();
@@ -539,7 +562,7 @@ int main(void)
     feed(frame, flen);
     CHECK(last_vfo_reply(&rep) && rep.status == DOCK_VFO_ERR_BAND,
           "0x0874: an out-of-band refusal from the radio side is reported");
-    CHECK(rep.rx_hz == 0 && rep.tx_hz == 0 && rep.ctcss_tenths == 0,
+    CHECK(rep.rx_hz == 0 && rep.tx_hz == 0 && rep.ctcss_tenths == 0 && rep.power == 0,
           "0x0874: a non-zero status ships no frequencies, whatever the HAL wrote");
 
     reset();

--- a/tests/host/test_dock.c
+++ b/tests/host/test_dock.c
@@ -1,0 +1,260 @@
+/* Host-side unit tests for App/app/dock.c — the UV-K5 V3 dock protocol core.
+ *
+ * The "definition of done" for the F2 port is byte-compatibility with
+ * radio-server's FirmwareFakeSerial + Uvk5Decoder
+ * (radio_server/backends/uvk5/, tests/test_uvk5_transport.py). These cases
+ * mirror that fake's acceptance / dispatch / reply rules and pin one
+ * byte-exact reply vector as an independent oracle.
+ *
+ * Build & run:  make -C tests/host run     (or: cc -I App tests/host/test_dock.c App/app/dock.c)
+ */
+
+#include "app/dock.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+/* ---- tiny test framework ---- */
+static int g_checks = 0, g_fail = 0;
+#define CHECK(cond, msg)                                                    \
+    do {                                                                    \
+        g_checks++;                                                         \
+        if (!(cond)) {                                                      \
+            printf("  FAIL: %s (line %d)\n", (msg), __LINE__);              \
+            g_fail++;                                                       \
+        }                                                                   \
+    } while (0)
+
+/* ---- fake HAL ---- */
+static uint16_t g_regs[256];
+static uint8_t  g_cap[2048];
+static uint16_t g_caplen;
+static int      g_reads, g_writes;
+
+static uint16_t hal_read(void *u, uint16_t reg)
+{
+    (void)u; g_reads++;
+    return g_regs[reg & 0xFF];
+}
+static void hal_write(void *u, uint16_t reg, uint16_t val)
+{
+    (void)u; g_writes++;
+    g_regs[reg & 0xFF] = val;
+}
+static void hal_send(void *u, const uint8_t *buf, uint16_t len)
+{
+    (void)u;
+    if ((uint32_t)g_caplen + len <= sizeof(g_cap)) {
+        memcpy(g_cap + g_caplen, buf, len);
+        g_caplen = (uint16_t)(g_caplen + len);
+    }
+}
+static const dock_hal_t HAL = { hal_read, hal_write, hal_send, NULL };
+
+static dock_ctx_t ctx;
+
+static void reset(void)
+{
+    memset(g_regs, 0, sizeof(g_regs));
+    g_caplen = 0; g_reads = 0; g_writes = 0;
+    dock_init(&ctx, &HAL);
+}
+
+/* Build an obfuscated COMMAND frame with a real CRC (what radio-server sends).
+ * payload = [opcode:u16][param_len:u16][params]; frame Size = 4 + param_len. */
+static uint16_t build_cmd(uint8_t *out, uint16_t opcode,
+                          const uint8_t *params, uint16_t plen)
+{
+    uint8_t body[DOCK_MAX_PAYLOAD + 2];
+    uint16_t size = (uint16_t)(4 + plen);
+    body[0] = (uint8_t)(opcode & 0xFF); body[1] = (uint8_t)(opcode >> 8);
+    body[2] = (uint8_t)(plen & 0xFF);   body[3] = (uint8_t)(plen >> 8);
+    memcpy(body + 4, params, plen);
+    uint16_t crc = dock_crc16(body, size);
+    body[size] = (uint8_t)(crc & 0xFF); body[size + 1] = (uint8_t)(crc >> 8);
+    dock_obfuscate(body, (uint16_t)(size + 2));
+
+    uint16_t n = 0;
+    out[n++] = 0xAB; out[n++] = 0xCD;
+    out[n++] = (uint8_t)(size & 0xFF); out[n++] = (uint8_t)(size >> 8);
+    memcpy(out + n, body, size + 2); n = (uint16_t)(n + size + 2);
+    out[n++] = 0xDC; out[n++] = 0xBA;
+    return n;
+}
+
+static void feed(const uint8_t *buf, uint16_t len)
+{
+    for (uint16_t i = 0; i < len; i++) dock_rx_byte(&ctx, buf[i]);
+}
+
+/* little-endian param builders */
+static uint16_t p_read(uint8_t *p, const uint16_t *regs, uint16_t count)
+{
+    uint16_t n = 0;
+    p[n++] = (uint8_t)(count & 0xFF); p[n++] = (uint8_t)(count >> 8);
+    for (uint16_t i = 0; i < count; i++) {
+        p[n++] = (uint8_t)(regs[i] & 0xFF); p[n++] = (uint8_t)(regs[i] >> 8);
+    }
+    return n;
+}
+static uint16_t p_write(uint8_t *p, const uint16_t *pairs, uint16_t count)
+{
+    uint16_t n = 0;
+    p[n++] = (uint8_t)(count & 0xFF); p[n++] = (uint8_t)(count >> 8);
+    for (uint16_t i = 0; i < count; i++) {
+        p[n++] = (uint8_t)(pairs[i * 2] & 0xFF);     p[n++] = (uint8_t)(pairs[i * 2] >> 8);
+        p[n++] = (uint8_t)(pairs[i * 2 + 1] & 0xFF); p[n++] = (uint8_t)(pairs[i * 2 + 1] >> 8);
+    }
+    return n;
+}
+
+int main(void)
+{
+    uint8_t frame[512], params[512];
+    uint16_t flen, plen;
+
+    /* 1. Connect probe: ReadRegisters([0x30]) -> exactly one 0x0951 reply,
+     *    byte-exact against a hand-computed golden (independent oracle). */
+    reset();
+    g_regs[0x30] = 0xC1FE;
+    { uint16_t r[] = { 0x30 }; plen = p_read(params, r, 1); }
+    flen = build_cmd(frame, DOCK_CMD_READ_REGS, params, plen);
+    feed(frame, flen);
+    {
+        static const uint8_t golden[] = {
+            0xAB, 0xCD, 0x08, 0x00,
+            0x47, 0x65, 0x10, 0xE6, 0x1E, 0x91, 0xF3, 0x81, 0xDE, 0xCA,
+            0xDC, 0xBA,
+        };
+        CHECK(g_reads == 1, "connect probe: exactly one register read");
+        CHECK(g_caplen == sizeof(golden), "connect probe: reply length");
+        CHECK(g_caplen == sizeof(golden) &&
+              memcmp(g_cap, golden, sizeof(golden)) == 0,
+              "connect probe: byte-exact 0x0951 reply vector");
+    }
+
+    /* 2. WriteRegisters -> no reply, register store updated. */
+    reset();
+    { uint16_t pr[] = { 0x30, 0xC1FE }; plen = p_write(params, pr, 1); }
+    flen = build_cmd(frame, DOCK_CMD_WRITE_REGS, params, plen);
+    feed(frame, flen);
+    CHECK(g_writes == 1 && g_regs[0x30] == 0xC1FE, "write: store updated");
+    CHECK(g_caplen == 0, "write: no reply");
+
+    /* 3. ReadRegisters of several -> one 0x0951 per register, in order. */
+    reset();
+    g_regs[0x38] = 0x1111; g_regs[0x39] = 0x2222; g_regs[0x33] = 0x3333;
+    { uint16_t r[] = { 0x38, 0x39, 0x33 }; plen = p_read(params, r, 3); }
+    flen = build_cmd(frame, DOCK_CMD_READ_REGS, params, plen);
+    feed(frame, flen);
+    CHECK(g_reads == 3, "multi-read: three reads");
+    CHECK(g_caplen == 3 * 16, "multi-read: three framed replies");
+    /* second reply's register field (offset 16 + 4, de-obfuscated) == 0x39 */
+    if (g_caplen == 48) {
+        uint8_t body[10];
+        memcpy(body, g_cap + 16 + 4, 10);            /* 2nd frame, payload at +4 */
+        dock_obfuscate(body, 10);
+        /* payload = [opcode:u16][param_len:u16][reg:u16][value:u16] */
+        uint16_t op  = (uint16_t)(body[0] | (body[1] << 8));
+        uint16_t reg = (uint16_t)(body[4] | (body[5] << 8));
+        uint16_t val = (uint16_t)(body[6] | (body[7] << 8));
+        CHECK(op == DOCK_REPLY_REG_INFO && reg == 0x39 && val == 0x2222,
+              "multi-read: 2nd reply opcode/reg/value");
+    }
+
+    /* 4. Bad command CRC -> dropped: no dispatch, no reply. */
+    reset();
+    { uint16_t r[] = { 0x30 }; plen = p_read(params, r, 1); }
+    flen = build_cmd(frame, DOCK_CMD_READ_REGS, params, plen);
+    frame[6] ^= 0xFF;                 /* corrupt an obfuscated payload byte */
+    feed(frame, flen);
+    CHECK(g_reads == 0 && g_caplen == 0, "bad CRC: dropped");
+
+    /* 5. Bad footer -> dropped. */
+    reset();
+    { uint16_t r[] = { 0x30 }; plen = p_read(params, r, 1); }
+    flen = build_cmd(frame, DOCK_CMD_READ_REGS, params, plen);
+    frame[flen - 1] = 0x00;           /* break 0xBA */
+    feed(frame, flen);
+    CHECK(g_reads == 0 && g_caplen == 0, "bad footer: dropped");
+
+    /* 6. Zero-size frame -> dropped, and a following good frame still parses. */
+    reset();
+    g_regs[0x30] = 0x1234;
+    {
+        uint8_t junk[] = { 0xAB, 0xCD, 0x00, 0x00, 0xDC, 0xBA };
+        feed(junk, sizeof(junk));
+        CHECK(g_caplen == 0, "zero-size: dropped");
+        { uint16_t r[] = { 0x30 }; plen = p_read(params, r, 1); }
+        flen = build_cmd(frame, DOCK_CMD_READ_REGS, params, plen);
+        feed(frame, flen);
+        CHECK(g_reads == 1, "recover after zero-size");
+    }
+
+    /* 7. Oversize (Size > 254) -> dropped. */
+    reset();
+    {
+        uint8_t big[8] = { 0xAB, 0xCD, 0xFF, 0x00 /* Size=255 */, 0, 0, 0xDC, 0xBA };
+        feed(big, sizeof(big));
+        CHECK(g_reads == 0 && g_caplen == 0, "oversize: dropped");
+    }
+
+    /* 8. Leading garbage + bad 2nd-preamble byte, then a good frame. */
+    reset();
+    g_regs[0x30] = 0x55AA;
+    {
+        uint8_t noise[] = { 0x00, 0x11, 0xAB, 0x00, 0xAB, 0x22 };  /* AB not followed by CD */
+        feed(noise, sizeof(noise));
+        { uint16_t r[] = { 0x30 }; plen = p_read(params, r, 1); }
+        flen = build_cmd(frame, DOCK_CMD_READ_REGS, params, plen);
+        feed(frame, flen);
+        CHECK(g_reads == 1, "resync past garbage / bad 2nd preamble");
+    }
+
+    /* 9. Frame split one byte at a time still parses (streaming). */
+    reset();
+    g_regs[0x30] = 0xABCD;
+    { uint16_t r[] = { 0x30 }; plen = p_read(params, r, 1); }
+    flen = build_cmd(frame, DOCK_CMD_READ_REGS, params, plen);
+    feed(frame, flen);               /* feed() already delivers byte-by-byte */
+    CHECK(g_reads == 1 && g_caplen == 16, "streaming byte-by-byte");
+
+    /* 10. Full-control: 0x0870 sets flag; register R/W works while in it;
+     *     0x0871 clears it. (Matches the fake's full_control flag + shared dispatch.) */
+    reset();
+    flen = build_cmd(frame, DOCK_CMD_ENTER_HW, params, 0);
+    feed(frame, flen);
+    CHECK(ctx.full_control, "0x0870 enters full-control");
+    g_regs[0x30] = 0x0BEE;
+    { uint16_t r[] = { 0x30 }; plen = p_read(params, r, 1); }
+    flen = build_cmd(frame, DOCK_CMD_READ_REGS, params, plen);
+    feed(frame, flen);
+    CHECK(g_reads == 1 && ctx.full_control, "read works inside full-control");
+    flen = build_cmd(frame, DOCK_CMD_EXIT_HW, params, 0);
+    feed(frame, flen);
+    CHECK(!ctx.full_control, "0x0871 exits full-control");
+
+    /* 11. Malformed frame immediately followed by a good one, single buffer. */
+    reset();
+    g_regs[0x51] = 0x9999;
+    {
+        uint8_t buf[600]; uint16_t n = 0;
+        uint16_t bad = build_cmd(frame, DOCK_CMD_READ_REGS, params, 0); /* count=0 read: valid but no reply */
+        (void)bad;
+        /* a truly malformed lead: AB CD with wrong footer */
+        uint8_t junk[] = { 0xAB, 0xCD, 0x04, 0x00, 1, 2, 3, 4, 5, 6, 0x00, 0x00 };
+        memcpy(buf + n, junk, sizeof(junk)); n = (uint16_t)(n + sizeof(junk));
+        { uint16_t r[] = { 0x51 }; plen = p_read(params, r, 1); }
+        flen = build_cmd(frame, DOCK_CMD_READ_REGS, params, plen);
+        memcpy(buf + n, frame, flen); n = (uint16_t)(n + flen);
+        feed(buf, n);
+        CHECK(g_reads == 1, "good frame after malformed in same buffer");
+    }
+
+    /* ---- report ---- */
+    printf("dock host tests: %d checks, %d failures\n", g_checks, g_fail);
+    if (g_fail) { printf("RESULT: FAIL\n"); return 1; }
+    printf("RESULT: PASS\n");
+    return 0;
+}

--- a/tests/host/test_dock.c
+++ b/tests/host/test_dock.c
@@ -68,7 +68,7 @@ static void hal_tx(void *u, bool on)
     (void)u; g_tx_calls++; g_tx_last = on ? 1 : 0;
     ev_push(on ? '1' : '0');
 }
-/* set-VFO spy (0x0872). Records the last decoded channel and how many times the
+/* set-VFO spy (0x0873). Records the last decoded channel and how many times the
  * firmware would have been asked to apply one — the count is what proves a
  * malformed or out-of-range frame was REFUSED rather than quietly passed on to
  * the radio's own VFO struct. */
@@ -335,7 +335,7 @@ int main(void)
     flen = build_cmd(frame, DOCK_CMD_EXIT_HW, params, 0); feed(frame, flen);    /* 0x0871 */
     CHECK(g_tx_calls == 4 && g_tx_last == 0 && !ctx.tx_on, "0x0871 exit drops the PA");
 
-    /* ---- 0x0872 set-VFO -------------------------------------------------
+    /* ---- 0x0873 set-VFO -------------------------------------------------
      *
      * This is the one command whose whole point is to outlive the dock session,
      * so its failure modes are different in kind from the register commands:
@@ -358,14 +358,14 @@ int main(void)
         flen = build_cmd(frame, DOCK_CMD_SET_VFO, v, sizeof(v));
         feed(frame, flen);
     }
-    CHECK(g_vfo_calls == 1, "0x0872: a well-formed channel is applied once");
-    CHECK(g_vfo_last.rx_hz == 448525000u, "0x0872: rx frequency decoded");
-    CHECK(g_vfo_last.offset_hz == 5000000u, "0x0872: offset decoded");
-    CHECK(g_vfo_last.ctcss_tenths == 1000u, "0x0872: CTCSS decoded in tenths");
-    CHECK(g_vfo_last.direction == DOCK_OFFSET_SUB, "0x0872: direction decoded");
-    CHECK(g_vfo_last.narrow == 0 && g_vfo_last.power == 2, "0x0872: bandwidth/power decoded");
-    CHECK(g_writes == 0, "0x0872: writes no registers itself");
-    CHECK(g_caplen == 0, "0x0872: sends no reply");
+    CHECK(g_vfo_calls == 1, "0x0873: a well-formed channel is applied once");
+    CHECK(g_vfo_last.rx_hz == 448525000u, "0x0873: rx frequency decoded");
+    CHECK(g_vfo_last.offset_hz == 5000000u, "0x0873: offset decoded");
+    CHECK(g_vfo_last.ctcss_tenths == 1000u, "0x0873: CTCSS decoded in tenths");
+    CHECK(g_vfo_last.direction == DOCK_OFFSET_SUB, "0x0873: direction decoded");
+    CHECK(g_vfo_last.narrow == 0 && g_vfo_last.power == 2, "0x0873: bandwidth/power decoded");
+    CHECK(g_writes == 0, "0x0873: writes no registers itself");
+    CHECK(g_caplen == 0, "0x0873: sends no reply");
 
     /* 18. A simplex channel is expressible: no offset, no tone. */
     reset();
@@ -379,9 +379,9 @@ int main(void)
         flen = build_cmd(frame, DOCK_CMD_SET_VFO, v, sizeof(v));
         feed(frame, flen);
     }
-    CHECK(g_vfo_calls == 1 && g_vfo_last.rx_hz == 445800000u, "0x0872: simplex channel applies");
+    CHECK(g_vfo_calls == 1 && g_vfo_last.rx_hz == 445800000u, "0x0873: simplex channel applies");
     CHECK(g_vfo_last.ctcss_tenths == 0 && g_vfo_last.direction == DOCK_OFFSET_NONE,
-          "0x0872: no tone and no offset survive as zero, not as garbage");
+          "0x0873: no tone and no offset survive as zero, not as garbage");
 
     /* 19. A truncated payload is refused, not read past. The frame is otherwise
      *     valid, so nothing but the length check stands between a short frame
@@ -392,7 +392,7 @@ int main(void)
         flen = build_cmd(frame, DOCK_CMD_SET_VFO, v, sizeof(v));
         feed(frame, flen);
     }
-    CHECK(g_vfo_calls == 0, "0x0872: a short payload is refused");
+    CHECK(g_vfo_calls == 0, "0x0873: a short payload is refused");
 
     /* 20. Out-of-range fields are refused rather than clamped. A bad direction
      *     byte silently treated as "simplex" would transmit on the repeater's
@@ -406,17 +406,17 @@ int main(void)
         };
         flen = build_cmd(frame, DOCK_CMD_SET_VFO, v, sizeof(v));
         feed(frame, flen);
-        CHECK(g_vfo_calls == 0, "0x0872: an unknown offset direction is refused");
+        CHECK(g_vfo_calls == 0, "0x0873: an unknown offset direction is refused");
 
         v[10] = DOCK_OFFSET_SUB; v[11] = 0x05;    /* bandwidth: neither wide nor narrow */
         flen = build_cmd(frame, DOCK_CMD_SET_VFO, v, sizeof(v));
         feed(frame, flen);
-        CHECK(g_vfo_calls == 0, "0x0872: an unknown bandwidth is refused");
+        CHECK(g_vfo_calls == 0, "0x0873: an unknown bandwidth is refused");
 
         v[11] = 0; v[12] = 0x09;                  /* power: off the end of the scale */
         flen = build_cmd(frame, DOCK_CMD_SET_VFO, v, sizeof(v));
         feed(frame, flen);
-        CHECK(g_vfo_calls == 0, "0x0872: an unknown power level is refused");
+        CHECK(g_vfo_calls == 0, "0x0873: an unknown power level is refused");
     }
 
     /* 21. Refused inside full-control. Applying a VFO mid-dock would call
@@ -430,18 +430,18 @@ int main(void)
         };
         flen = build_cmd(frame, DOCK_CMD_SET_VFO, v, sizeof(v));
         feed(frame, flen);
-        CHECK(g_vfo_calls == 0, "0x0872: refused while the host holds full-control");
+        CHECK(g_vfo_calls == 0, "0x0873: refused while the host holds full-control");
 
         flen = build_cmd(frame, DOCK_CMD_EXIT_HW, params, 0); feed(frame, flen);
         flen = build_cmd(frame, DOCK_CMD_SET_VFO, v, sizeof(v));
         feed(frame, flen);
-        CHECK(g_vfo_calls == 1, "0x0872: accepted once full-control is released");
+        CHECK(g_vfo_calls == 1, "0x0873: accepted once full-control is released");
     }
 
     /* 22. Never keys. This command runs while the radio is a radio, so if it
      *     could touch the TX state it would key one outside the dock's own
      *     fail-safe seams, with nothing tracking it. */
-    CHECK(g_tx_calls == 0 && !ctx.tx_on, "0x0872: no PA activity of its own");
+    CHECK(g_tx_calls == 0 && !ctx.tx_on, "0x0873: no PA activity of its own");
 
     /* ---- report ---- */
     printf("dock host tests: %d checks, %d failures\n", g_checks, g_fail);

--- a/tests/host/test_dock.c
+++ b/tests/host/test_dock.c
@@ -71,15 +71,57 @@ static void hal_tx(void *u, bool on)
 /* set-VFO spy (0x0873). Records the last decoded channel and how many times the
  * firmware would have been asked to apply one — the count is what proves a
  * malformed or out-of-range frame was REFUSED rather than quietly passed on to
- * the radio's own VFO struct. */
+ * the radio's own VFO struct.
+ *
+ * g_vfo_force_status makes the fake binding refuse the way the real one does
+ * for the two conditions only it can see (band, tone). It then ALSO fills in
+ * frequencies, deliberately, so the tests can prove dock.c blanks them: a
+ * non-zero status must never ship a channel the radio is not on. */
 static int        g_vfo_calls;
 static dock_vfo_t g_vfo_last;
+static uint8_t    g_vfo_force_status;
 
-static void hal_set_vfo(void *u, const dock_vfo_t *vfo)
+static void hal_set_vfo(void *u, const dock_vfo_t *vfo, dock_vfo_applied_t *out)
 {
     (void)u; g_vfo_calls++; g_vfo_last = *vfo;
+    if (g_vfo_force_status != DOCK_VFO_APPLIED) {
+        out->status       = g_vfo_force_status;
+        out->rx_hz        = 0xDEADBEEFu;
+        out->tx_hz        = 0xFEEDFACEu;
+        out->ctcss_tenths = 0x1234u;
+        return;
+    }
+    out->status       = DOCK_VFO_APPLIED;
+    out->rx_hz        = vfo->rx_hz;
+    out->tx_hz        = (vfo->direction == DOCK_OFFSET_ADD) ? vfo->rx_hz + vfo->offset_hz
+                      : (vfo->direction == DOCK_OFFSET_SUB) ? vfo->rx_hz - vfo->offset_hz
+                      : vfo->rx_hz;
+    out->ctcss_tenths = vfo->ctcss_tenths;
 }
 static const dock_hal_t HAL = { hal_read, hal_write, hal_send, NULL, hal_tx, hal_set_vfo };
+/* A build with no radio-side binding at all — 0x0873 must still answer. */
+static const dock_hal_t HAL_NO_VFO = { hal_read, hal_write, hal_send, NULL, hal_tx, NULL };
+
+/* Decode the one 0x0874 reply in the capture buffer. False unless exactly one
+ * well-formed reply is there, so "sent nothing" can never read as a pass. */
+#define VFO_REPLY_FRAME_LEN 24u   /* AB CD | size:2 | (4 + 12 + 2) | DC BA */
+
+static bool last_vfo_reply(dock_vfo_applied_t *out)
+{
+    if (g_caplen != VFO_REPLY_FRAME_LEN) return false;
+    uint8_t body[4 + 12 + 2];
+    memcpy(body, g_cap + 4, sizeof(body));
+    dock_obfuscate(body, (uint16_t)sizeof(body));
+    if ((uint16_t)(body[0] | (body[1] << 8)) != DOCK_REPLY_SET_VFO) return false;
+    if ((uint16_t)(body[2] | (body[3] << 8)) != 12u) return false;
+    out->status = body[4];
+    out->rx_hz  = (uint32_t)body[6]  | ((uint32_t)body[7] << 8)
+                | ((uint32_t)body[8] << 16) | ((uint32_t)body[9] << 24);
+    out->tx_hz  = (uint32_t)body[10] | ((uint32_t)body[11] << 8)
+                | ((uint32_t)body[12] << 16) | ((uint32_t)body[13] << 24);
+    out->ctcss_tenths = (uint16_t)(body[14] | (body[15] << 8));
+    return true;
+}
 
 static dock_ctx_t ctx;
 
@@ -89,6 +131,7 @@ static void reset(void)
     g_caplen = 0; g_reads = 0; g_writes = 0;
     g_tx_calls = 0; g_tx_last = -1; g_evn = 0; memset(g_ev, 0, sizeof(g_ev));
     g_vfo_calls = 0; memset(&g_vfo_last, 0, sizeof(g_vfo_last));
+    g_vfo_force_status = DOCK_VFO_APPLIED;
     dock_init(&ctx, &HAL);
 }
 
@@ -343,21 +386,21 @@ int main(void)
      * VFO written wrong is what the radio transmits on after we walk away.
      * Hence "refuse" rather than "clamp" everywhere below. */
 
-    /* 17. A well-formed repeater channel decodes field for field. K0PRA:
-     *     receive 448.525, transmit 5 MHz down, 100.0 Hz, wide, high power. */
+    /* K0PRA: receive 448.525, transmit 5 MHz down, 100.0 Hz, wide, high power. */
+    static const uint8_t K0PRA[DOCK_SET_VFO_PARAM_LEN] = {
+        0xC8, 0xF2, 0xBB, 0x1A,   /* rx_hz  448 525 000 */
+        0x40, 0x4B, 0x4C, 0x00,   /* offset   5 000 000 */
+        0xE8, 0x03,               /* ctcss tenths 1000 = 100.0 Hz */
+        DOCK_OFFSET_SUB,          /* direction */
+        0x00,                     /* wide */
+        0x02,                     /* high power */
+    };
+    dock_vfo_applied_t rep;
+
+    /* 17. A well-formed repeater channel decodes field for field. */
     reset();
-    {
-        uint8_t v[DOCK_SET_VFO_PARAM_LEN] = {
-            0xC8, 0xF2, 0xBB, 0x1A,   /* rx_hz  448 525 000 */
-            0x40, 0x4B, 0x4C, 0x00,   /* offset   5 000 000 */
-            0xE8, 0x03,               /* ctcss tenths 1000 = 100.0 Hz */
-            DOCK_OFFSET_SUB,          /* direction */
-            0x00,                     /* wide */
-            0x02,                     /* high power */
-        };
-        flen = build_cmd(frame, DOCK_CMD_SET_VFO, v, sizeof(v));
-        feed(frame, flen);
-    }
+    flen = build_cmd(frame, DOCK_CMD_SET_VFO, K0PRA, sizeof(K0PRA));
+    feed(frame, flen);
     CHECK(g_vfo_calls == 1, "0x0873: a well-formed channel is applied once");
     CHECK(g_vfo_last.rx_hz == 448525000u, "0x0873: rx frequency decoded");
     CHECK(g_vfo_last.offset_hz == 5000000u, "0x0873: offset decoded");
@@ -365,7 +408,24 @@ int main(void)
     CHECK(g_vfo_last.direction == DOCK_OFFSET_SUB, "0x0873: direction decoded");
     CHECK(g_vfo_last.narrow == 0 && g_vfo_last.power == 2, "0x0873: bandwidth/power decoded");
     CHECK(g_writes == 0, "0x0873: writes no registers itself");
-    CHECK(g_caplen == 0, "0x0873: sends no reply");
+    CHECK(last_vfo_reply(&rep), "0x0874: exactly one well-formed reply");
+    CHECK(rep.status == DOCK_VFO_APPLIED, "0x0874: applied");
+    CHECK(rep.rx_hz == 448525000u && rep.tx_hz == 443525000u,
+          "0x0874: reports BOTH legs, so the caller learns where it will radiate");
+    CHECK(rep.ctcss_tenths == 1000u, "0x0874: reports the tone actually set");
+
+    /* 17b. Byte-exact reply vector — an oracle independent of this file's own
+     *      builders, and the thing radio-server's decoder is written against. */
+    {
+        static const uint8_t golden[] = {
+            0xAB, 0xCD, 0x10, 0x00, 0x62, 0x64, 0x18, 0xE6,
+            0x2E, 0x91, 0xC5, 0xB2, 0x9A, 0x2F, 0x5D, 0xE7,
+            0x7C, 0x19, 0x01, 0x83, 0xE9, 0x93, 0xDC, 0xBA,
+        };
+        CHECK(g_caplen == sizeof(golden), "0x0874: golden reply length");
+        CHECK(g_caplen == sizeof(golden) &&
+              memcmp(g_cap, golden, sizeof(golden)) == 0, "0x0874: byte-exact reply");
+    }
 
     /* 18. A simplex channel is expressible: no offset, no tone. */
     reset();
@@ -382,10 +442,14 @@ int main(void)
     CHECK(g_vfo_calls == 1 && g_vfo_last.rx_hz == 445800000u, "0x0873: simplex channel applies");
     CHECK(g_vfo_last.ctcss_tenths == 0 && g_vfo_last.direction == DOCK_OFFSET_NONE,
           "0x0873: no tone and no offset survive as zero, not as garbage");
+    CHECK(last_vfo_reply(&rep) && rep.status == DOCK_VFO_APPLIED
+          && rep.rx_hz == 445800000u && rep.tx_hz == 445800000u,
+          "0x0874: simplex reports the same frequency on both legs");
 
     /* 19. A truncated payload is refused, not read past. The frame is otherwise
      *     valid, so nothing but the length check stands between a short frame
-     *     and reading whatever follows it in the RX buffer. */
+     *     and reading whatever follows it in the RX buffer. It still answers:
+     *     a caller that mis-sized its own frame most needs to be told. */
     reset();
     {
         uint8_t v[DOCK_SET_VFO_PARAM_LEN - 1] = { 0 };
@@ -393,30 +457,42 @@ int main(void)
         feed(frame, flen);
     }
     CHECK(g_vfo_calls == 0, "0x0873: a short payload is refused");
+    CHECK(last_vfo_reply(&rep) && rep.status == DOCK_VFO_ERR_SHORT,
+          "0x0874: a short payload is REPORTED, not swallowed");
 
-    /* 20. Out-of-range fields are refused rather than clamped. A bad direction
-     *     byte silently treated as "simplex" would transmit on the repeater's
-     *     OUTPUT — on top of the machine, and on top of whoever it is repeating. */
-    reset();
+    /* 20. Out-of-range fields are refused rather than clamped, and each names
+     *     its own reason. A bad direction byte silently treated as "simplex"
+     *     would transmit on the repeater's OUTPUT — on top of the machine, and
+     *     on top of whoever it is repeating. */
     {
-        uint8_t v[DOCK_SET_VFO_PARAM_LEN] = {
-            0x40, 0x5E, 0x92, 0x1A, 0x40, 0x4B, 0x4C, 0x00, 0xE8, 0x03,
-            0x07,        /* direction: not one of NONE/ADD/SUB */
-            0, 1,
-        };
+        uint8_t v[DOCK_SET_VFO_PARAM_LEN];
+        memcpy(v, K0PRA, sizeof(v));
+
+        reset();
+        v[10] = 0x07;                             /* direction: not NONE/ADD/SUB */
         flen = build_cmd(frame, DOCK_CMD_SET_VFO, v, sizeof(v));
         feed(frame, flen);
         CHECK(g_vfo_calls == 0, "0x0873: an unknown offset direction is refused");
+        CHECK(last_vfo_reply(&rep) && rep.status == DOCK_VFO_ERR_DIRECTION,
+              "0x0874: the direction is named as the reason");
 
-        v[10] = DOCK_OFFSET_SUB; v[11] = 0x05;    /* bandwidth: neither wide nor narrow */
+        reset();
+        memcpy(v, K0PRA, sizeof(v));
+        v[11] = 0x05;                             /* bandwidth: neither wide nor narrow */
         flen = build_cmd(frame, DOCK_CMD_SET_VFO, v, sizeof(v));
         feed(frame, flen);
         CHECK(g_vfo_calls == 0, "0x0873: an unknown bandwidth is refused");
+        CHECK(last_vfo_reply(&rep) && rep.status == DOCK_VFO_ERR_FIELD,
+              "0x0874: a bad bandwidth is reported");
 
-        v[11] = 0; v[12] = 0x09;                  /* power: off the end of the scale */
+        reset();
+        memcpy(v, K0PRA, sizeof(v));
+        v[12] = 0x09;                             /* power: off the end of the scale */
         flen = build_cmd(frame, DOCK_CMD_SET_VFO, v, sizeof(v));
         feed(frame, flen);
         CHECK(g_vfo_calls == 0, "0x0873: an unknown power level is refused");
+        CHECK(last_vfo_reply(&rep) && rep.status == DOCK_VFO_ERR_FIELD,
+              "0x0874: a bad power level is reported");
     }
 
     /* 21. Refused inside full-control. Applying a VFO mid-dock would call
@@ -424,24 +500,55 @@ int main(void)
      *     synthesiser — the "adopt whatever you find" fault ADR 0132 removed. */
     reset();
     flen = build_cmd(frame, DOCK_CMD_ENTER_HW, params, 0); feed(frame, flen);
-    {
-        uint8_t v[DOCK_SET_VFO_PARAM_LEN] = {
-            0x40, 0x5E, 0x92, 0x1A, 0, 0, 0, 0, 0, 0, DOCK_OFFSET_NONE, 0, 1,
-        };
-        flen = build_cmd(frame, DOCK_CMD_SET_VFO, v, sizeof(v));
-        feed(frame, flen);
-        CHECK(g_vfo_calls == 0, "0x0873: refused while the host holds full-control");
+    g_caplen = 0;                                  /* drop the enter's own traffic */
+    flen = build_cmd(frame, DOCK_CMD_SET_VFO, K0PRA, sizeof(K0PRA));
+    feed(frame, flen);
+    CHECK(g_vfo_calls == 0, "0x0873: refused while the host holds full-control");
+    CHECK(last_vfo_reply(&rep) && rep.status == DOCK_VFO_ERR_BUSY,
+          "0x0874: full-control is named, so the caller can retry after 0x0871");
 
-        flen = build_cmd(frame, DOCK_CMD_EXIT_HW, params, 0); feed(frame, flen);
-        flen = build_cmd(frame, DOCK_CMD_SET_VFO, v, sizeof(v));
-        feed(frame, flen);
-        CHECK(g_vfo_calls == 1, "0x0873: accepted once full-control is released");
-    }
+    flen = build_cmd(frame, DOCK_CMD_EXIT_HW, params, 0); feed(frame, flen);
+    g_caplen = 0;
+    flen = build_cmd(frame, DOCK_CMD_SET_VFO, K0PRA, sizeof(K0PRA));
+    feed(frame, flen);
+    CHECK(g_vfo_calls == 1, "0x0873: accepted once full-control is released");
+    CHECK(last_vfo_reply(&rep) && rep.status == DOCK_VFO_APPLIED,
+          "0x0874: applied after full-control is released");
 
     /* 22. Never keys. This command runs while the radio is a radio, so if it
      *     could touch the TX state it would key one outside the dock's own
      *     fail-safe seams, with nothing tracking it. */
     CHECK(g_tx_calls == 0 && !ctx.tx_on, "0x0873: no PA activity of its own");
+
+    /* 23. A build with no radio-side binding still answers. Silence here would
+     *     be indistinguishable from a radio that is not listening at all. */
+    reset();
+    dock_init(&ctx, &HAL_NO_VFO);
+    flen = build_cmd(frame, DOCK_CMD_SET_VFO, K0PRA, sizeof(K0PRA));
+    feed(frame, flen);
+    CHECK(last_vfo_reply(&rep) && rep.status == DOCK_VFO_ERR_NO_HAL,
+          "0x0874: a missing set_vfo binding is reported, not silent");
+
+    /* 24. A rejection never carries frequencies. The fake binding fills them in
+     *     on purpose; dock.c must blank them, so no caller can ever read a
+     *     channel off a reply that says the radio is not on one. This is the
+     *     whole contract in one case: status first, and it is authoritative. */
+    reset();
+    g_vfo_force_status = DOCK_VFO_ERR_BAND;
+    flen = build_cmd(frame, DOCK_CMD_SET_VFO, K0PRA, sizeof(K0PRA));
+    feed(frame, flen);
+    CHECK(last_vfo_reply(&rep) && rep.status == DOCK_VFO_ERR_BAND,
+          "0x0874: an out-of-band refusal from the radio side is reported");
+    CHECK(rep.rx_hz == 0 && rep.tx_hz == 0 && rep.ctcss_tenths == 0,
+          "0x0874: a non-zero status ships no frequencies, whatever the HAL wrote");
+
+    reset();
+    g_vfo_force_status = DOCK_VFO_ERR_TONE;
+    flen = build_cmd(frame, DOCK_CMD_SET_VFO, K0PRA, sizeof(K0PRA));
+    feed(frame, flen);
+    CHECK(last_vfo_reply(&rep) && rep.status == DOCK_VFO_ERR_TONE
+          && rep.rx_hz == 0 && rep.ctcss_tenths == 0,
+          "0x0874: an unresolvable tone refuses the whole tune, on frequency or not");
 
     /* ---- report ---- */
     printf("dock host tests: %d checks, %d failures\n", g_checks, g_fail);

--- a/tests/host/test_dock.c
+++ b/tests/host/test_dock.c
@@ -68,7 +68,18 @@ static void hal_tx(void *u, bool on)
     (void)u; g_tx_calls++; g_tx_last = on ? 1 : 0;
     ev_push(on ? '1' : '0');
 }
-static const dock_hal_t HAL = { hal_read, hal_write, hal_send, NULL, hal_tx };
+/* set-VFO spy (0x0872). Records the last decoded channel and how many times the
+ * firmware would have been asked to apply one — the count is what proves a
+ * malformed or out-of-range frame was REFUSED rather than quietly passed on to
+ * the radio's own VFO struct. */
+static int        g_vfo_calls;
+static dock_vfo_t g_vfo_last;
+
+static void hal_set_vfo(void *u, const dock_vfo_t *vfo)
+{
+    (void)u; g_vfo_calls++; g_vfo_last = *vfo;
+}
+static const dock_hal_t HAL = { hal_read, hal_write, hal_send, NULL, hal_tx, hal_set_vfo };
 
 static dock_ctx_t ctx;
 
@@ -77,6 +88,7 @@ static void reset(void)
     memset(g_regs, 0, sizeof(g_regs));
     g_caplen = 0; g_reads = 0; g_writes = 0;
     g_tx_calls = 0; g_tx_last = -1; g_evn = 0; memset(g_ev, 0, sizeof(g_ev));
+    g_vfo_calls = 0; memset(&g_vfo_last, 0, sizeof(g_vfo_last));
     dock_init(&ctx, &HAL);
 }
 
@@ -322,6 +334,114 @@ int main(void)
     CHECK(g_tx_calls == 3 && ctx.tx_on, "re-key inside full-control");
     flen = build_cmd(frame, DOCK_CMD_EXIT_HW, params, 0); feed(frame, flen);    /* 0x0871 */
     CHECK(g_tx_calls == 4 && g_tx_last == 0 && !ctx.tx_on, "0x0871 exit drops the PA");
+
+    /* ---- 0x0872 set-VFO -------------------------------------------------
+     *
+     * This is the one command whose whole point is to outlive the dock session,
+     * so its failure modes are different in kind from the register commands:
+     * a register write that goes wrong is undone by the next 0x0871, while a
+     * VFO written wrong is what the radio transmits on after we walk away.
+     * Hence "refuse" rather than "clamp" everywhere below. */
+
+    /* 17. A well-formed repeater channel decodes field for field. K0PRA:
+     *     receive 448.525, transmit 5 MHz down, 100.0 Hz, wide, high power. */
+    reset();
+    {
+        uint8_t v[DOCK_SET_VFO_PARAM_LEN] = {
+            0xC8, 0xF2, 0xBB, 0x1A,   /* rx_hz  448 525 000 */
+            0x40, 0x4B, 0x4C, 0x00,   /* offset   5 000 000 */
+            0xE8, 0x03,               /* ctcss tenths 1000 = 100.0 Hz */
+            DOCK_OFFSET_SUB,          /* direction */
+            0x00,                     /* wide */
+            0x02,                     /* high power */
+        };
+        flen = build_cmd(frame, DOCK_CMD_SET_VFO, v, sizeof(v));
+        feed(frame, flen);
+    }
+    CHECK(g_vfo_calls == 1, "0x0872: a well-formed channel is applied once");
+    CHECK(g_vfo_last.rx_hz == 448525000u, "0x0872: rx frequency decoded");
+    CHECK(g_vfo_last.offset_hz == 5000000u, "0x0872: offset decoded");
+    CHECK(g_vfo_last.ctcss_tenths == 1000u, "0x0872: CTCSS decoded in tenths");
+    CHECK(g_vfo_last.direction == DOCK_OFFSET_SUB, "0x0872: direction decoded");
+    CHECK(g_vfo_last.narrow == 0 && g_vfo_last.power == 2, "0x0872: bandwidth/power decoded");
+    CHECK(g_writes == 0, "0x0872: writes no registers itself");
+    CHECK(g_caplen == 0, "0x0872: sends no reply");
+
+    /* 18. A simplex channel is expressible: no offset, no tone. */
+    reset();
+    {
+        uint8_t v[DOCK_SET_VFO_PARAM_LEN] = {
+            0x40, 0x5E, 0x92, 0x1A,   /* 445 800 000 */
+            0, 0, 0, 0,               /* no offset */
+            0, 0,                     /* no tone */
+            DOCK_OFFSET_NONE, 0, 1,
+        };
+        flen = build_cmd(frame, DOCK_CMD_SET_VFO, v, sizeof(v));
+        feed(frame, flen);
+    }
+    CHECK(g_vfo_calls == 1 && g_vfo_last.rx_hz == 445800000u, "0x0872: simplex channel applies");
+    CHECK(g_vfo_last.ctcss_tenths == 0 && g_vfo_last.direction == DOCK_OFFSET_NONE,
+          "0x0872: no tone and no offset survive as zero, not as garbage");
+
+    /* 19. A truncated payload is refused, not read past. The frame is otherwise
+     *     valid, so nothing but the length check stands between a short frame
+     *     and reading whatever follows it in the RX buffer. */
+    reset();
+    {
+        uint8_t v[DOCK_SET_VFO_PARAM_LEN - 1] = { 0 };
+        flen = build_cmd(frame, DOCK_CMD_SET_VFO, v, sizeof(v));
+        feed(frame, flen);
+    }
+    CHECK(g_vfo_calls == 0, "0x0872: a short payload is refused");
+
+    /* 20. Out-of-range fields are refused rather than clamped. A bad direction
+     *     byte silently treated as "simplex" would transmit on the repeater's
+     *     OUTPUT — on top of the machine, and on top of whoever it is repeating. */
+    reset();
+    {
+        uint8_t v[DOCK_SET_VFO_PARAM_LEN] = {
+            0x40, 0x5E, 0x92, 0x1A, 0x40, 0x4B, 0x4C, 0x00, 0xE8, 0x03,
+            0x07,        /* direction: not one of NONE/ADD/SUB */
+            0, 1,
+        };
+        flen = build_cmd(frame, DOCK_CMD_SET_VFO, v, sizeof(v));
+        feed(frame, flen);
+        CHECK(g_vfo_calls == 0, "0x0872: an unknown offset direction is refused");
+
+        v[10] = DOCK_OFFSET_SUB; v[11] = 0x05;    /* bandwidth: neither wide nor narrow */
+        flen = build_cmd(frame, DOCK_CMD_SET_VFO, v, sizeof(v));
+        feed(frame, flen);
+        CHECK(g_vfo_calls == 0, "0x0872: an unknown bandwidth is refused");
+
+        v[11] = 0; v[12] = 0x09;                  /* power: off the end of the scale */
+        flen = build_cmd(frame, DOCK_CMD_SET_VFO, v, sizeof(v));
+        feed(frame, flen);
+        CHECK(g_vfo_calls == 0, "0x0872: an unknown power level is refused");
+    }
+
+    /* 21. Refused inside full-control. Applying a VFO mid-dock would call
+     *     RADIO_SetupRegisters underneath a host that believes it owns the
+     *     synthesiser — the "adopt whatever you find" fault ADR 0132 removed. */
+    reset();
+    flen = build_cmd(frame, DOCK_CMD_ENTER_HW, params, 0); feed(frame, flen);
+    {
+        uint8_t v[DOCK_SET_VFO_PARAM_LEN] = {
+            0x40, 0x5E, 0x92, 0x1A, 0, 0, 0, 0, 0, 0, DOCK_OFFSET_NONE, 0, 1,
+        };
+        flen = build_cmd(frame, DOCK_CMD_SET_VFO, v, sizeof(v));
+        feed(frame, flen);
+        CHECK(g_vfo_calls == 0, "0x0872: refused while the host holds full-control");
+
+        flen = build_cmd(frame, DOCK_CMD_EXIT_HW, params, 0); feed(frame, flen);
+        flen = build_cmd(frame, DOCK_CMD_SET_VFO, v, sizeof(v));
+        feed(frame, flen);
+        CHECK(g_vfo_calls == 1, "0x0872: accepted once full-control is released");
+    }
+
+    /* 22. Never keys. This command runs while the radio is a radio, so if it
+     *     could touch the TX state it would key one outside the dock's own
+     *     fail-safe seams, with nothing tracking it. */
+    CHECK(g_tx_calls == 0 && !ctx.tx_on, "0x0872: no PA activity of its own");
 
     /* ---- report ---- */
     printf("dock host tests: %d checks, %d failures\n", g_checks, g_fail);

--- a/tests/host/test_dock.c
+++ b/tests/host/test_dock.c
@@ -11,6 +11,7 @@
 
 #include "app/dock.h"
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -32,6 +33,17 @@ static uint8_t  g_cap[2048];
 static uint16_t g_caplen;
 static int      g_reads, g_writes;
 
+/* TX-state spy (F5). g_ev logs the *order* of events: 'w' on a REG_30 write,
+ * '1'/'0' on a tx_set(on/off) callback — so "1w" proves the PA edge is driven
+ * BEFORE the register write completes. */
+static int      g_tx_calls, g_tx_last;   /* g_tx_last: 1=on, 0=off, -1=none yet */
+static char     g_ev[128];
+static int      g_evn;
+
+static void ev_push(char c)
+{
+    if (g_evn < (int)sizeof(g_ev) - 1) g_ev[g_evn++] = c;
+}
 static uint16_t hal_read(void *u, uint16_t reg)
 {
     (void)u; g_reads++;
@@ -40,6 +52,7 @@ static uint16_t hal_read(void *u, uint16_t reg)
 static void hal_write(void *u, uint16_t reg, uint16_t val)
 {
     (void)u; g_writes++;
+    if ((reg & 0xFF) == 0x30) ev_push('w');
     g_regs[reg & 0xFF] = val;
 }
 static void hal_send(void *u, const uint8_t *buf, uint16_t len)
@@ -50,7 +63,12 @@ static void hal_send(void *u, const uint8_t *buf, uint16_t len)
         g_caplen = (uint16_t)(g_caplen + len);
     }
 }
-static const dock_hal_t HAL = { hal_read, hal_write, hal_send, NULL };
+static void hal_tx(void *u, bool on)
+{
+    (void)u; g_tx_calls++; g_tx_last = on ? 1 : 0;
+    ev_push(on ? '1' : '0');
+}
+static const dock_hal_t HAL = { hal_read, hal_write, hal_send, NULL, hal_tx };
 
 static dock_ctx_t ctx;
 
@@ -58,6 +76,7 @@ static void reset(void)
 {
     memset(g_regs, 0, sizeof(g_regs));
     g_caplen = 0; g_reads = 0; g_writes = 0;
+    g_tx_calls = 0; g_tx_last = -1; g_evn = 0; memset(g_ev, 0, sizeof(g_ev));
     dock_init(&ctx, &HAL);
 }
 
@@ -251,6 +270,58 @@ int main(void)
         feed(buf, n);
         CHECK(g_reads == 1, "good frame after malformed in same buffer");
     }
+
+    /* ===== F5: REG_30 TX-state seam (drives the physical PA) ===== */
+    /* The app's TX word is 0xC1FE (ENABLE_TX_DSP, bit1, set); its RX word is
+     * 0xBFF1 (TX_DSP clear). dock.c edge-detects that bit and calls tx_set()
+     * BEFORE completing the REG_30 write. */
+
+    /* 12. Key: write REG_30=0xC1FE -> tx_set(true) fires once, before the write. */
+    reset();
+    { uint16_t pr[] = { 0x30, 0xC1FE }; plen = p_write(params, pr, 1); }
+    flen = build_cmd(frame, DOCK_CMD_WRITE_REGS, params, plen);
+    feed(frame, flen);
+    CHECK(g_tx_calls == 1 && g_tx_last == 1, "key: tx_set(true) fires once");
+    CHECK(strcmp(g_ev, "1w") == 0, "key: PA engaged BEFORE the REG_30 write");
+    CHECK(ctx.tx_on && g_regs[0x30] == 0xC1FE, "key: tx_on set, REG_30 written");
+
+    /* 13. Key then un-key: each edge drives the PA before its write ("1w0w"). */
+    reset();
+    { uint16_t pr[] = { 0x30, 0xC1FE }; plen = p_write(params, pr, 1); }
+    flen = build_cmd(frame, DOCK_CMD_WRITE_REGS, params, plen); feed(frame, flen);
+    { uint16_t pr[] = { 0x30, 0xBFF1 }; plen = p_write(params, pr, 1); }
+    flen = build_cmd(frame, DOCK_CMD_WRITE_REGS, params, plen); feed(frame, flen);
+    CHECK(g_tx_calls == 2 && g_tx_last == 0, "un-key: tx_set(false) fires");
+    CHECK(strcmp(g_ev, "1w0w") == 0, "each PA edge precedes its REG_30 write");
+    CHECK(!ctx.tx_on, "un-key: tx_on cleared");
+
+    /* 14. Edge-detect: repeated same-state key writes fire tx_set once. */
+    reset();
+    for (int k = 0; k < 3; k++) {
+        uint16_t pr[] = { 0x30, 0xC1FE }; plen = p_write(params, pr, 1);
+        flen = build_cmd(frame, DOCK_CMD_WRITE_REGS, params, plen); feed(frame, flen);
+    }
+    CHECK(g_tx_calls == 1 && g_writes == 3, "repeat key: one PA engage, three writes");
+    CHECK(strcmp(g_ev, "1www") == 0, "repeat key: PA edge only on the first write");
+
+    /* 15. Writes to other registers never touch the TX state. */
+    reset();
+    { uint16_t pr[] = { 0x38, 0xC1FE, 0x36, 0x7FFF }; plen = p_write(params, pr, 2); }
+    flen = build_cmd(frame, DOCK_CMD_WRITE_REGS, params, plen);
+    feed(frame, flen);
+    CHECK(g_tx_calls == 0 && !ctx.tx_on, "non-REG_30 writes never key");
+
+    /* 16. Fail-safe: a dangling key is dropped at 0x0870 enter and at 0x0871 exit. */
+    reset();
+    { uint16_t pr[] = { 0x30, 0xC1FE }; plen = p_write(params, pr, 1); }        /* key, no un-key */
+    flen = build_cmd(frame, DOCK_CMD_WRITE_REGS, params, plen); feed(frame, flen);
+    flen = build_cmd(frame, DOCK_CMD_ENTER_HW, params, 0); feed(frame, flen);   /* 0x0870 */
+    CHECK(g_tx_calls == 2 && g_tx_last == 0 && !ctx.tx_on, "0x0870 enter clears a stale key");
+    { uint16_t pr[] = { 0x30, 0xC1FE }; plen = p_write(params, pr, 1); }        /* key again inside */
+    flen = build_cmd(frame, DOCK_CMD_WRITE_REGS, params, plen); feed(frame, flen);
+    CHECK(g_tx_calls == 3 && ctx.tx_on, "re-key inside full-control");
+    flen = build_cmd(frame, DOCK_CMD_EXIT_HW, params, 0); feed(frame, flen);    /* 0x0871 */
+    CHECK(g_tx_calls == 4 && g_tx_last == 0 && !ctx.tx_on, "0x0871 exit drops the PA");
 
     /* ---- report ---- */
     printf("dock host tests: %d checks, %d failures\n", g_checks, g_fail);

--- a/tests/host/test_dock.c
+++ b/tests/host/test_dock.c
@@ -105,9 +105,53 @@ static void hal_set_vfo(void *u, const dock_vfo_t *vfo, dock_vfo_applied_t *out)
     out->ctcss_tenths = vfo->ctcss_tenths;
     out->power        = FAKE_POWER_MAP[vfo->power];
 }
-static const dock_hal_t HAL = { hal_read, hal_write, hal_send, NULL, hal_tx, hal_set_vfo };
+/* set-modulation spy (0x0877). Same shape and same job as the set-VFO spy: the
+ * CALL COUNT is what proves a refused frame never reached the radio.
+ *
+ * g_mod_force_readback lets a test make the fake report a modulation OTHER than the
+ * one it was handed. That is not a contrived case — it is the whole reason 0x0878
+ * carries a read-back at all, and the 0x0874 `power` bug (wire 2 "high" landing on
+ * OUTPUT_POWER_LOW2) is what a reply that merely echoes the request looks like. */
+static int     g_mod_calls;
+static uint8_t g_mod_last;
+static uint8_t g_mod_force_status;    /* non-zero: refuse the way a HAL might */
+static int     g_mod_force_readback;  /* <0 = report what was asked for */
+static int     g_mod_force_raw;       /* <0 = derive from the readback */
+static uint8_t g_mod_force_flags;
+
+static void hal_set_modulation(void *u, uint8_t wire_mod, dock_mod_applied_t *out)
+{
+    (void)u; g_mod_calls++; g_mod_last = wire_mod;
+    if (g_mod_force_status != DOCK_MOD_APPLIED) {
+        /* Fill in a plausible-looking modulation on a refusal, deliberately, so the
+         * tests can prove dock.c overwrites it with DOCK_MOD_UNKNOWN. A binding that
+         * forgets must not be able to publish a modulation the radio is not on. */
+        out->status     = g_mod_force_status;
+        out->modulation = DOCK_MOD_FM;
+        out->raw        = 0u;
+        out->flags      = DOCK_MOD_FLAG_TX_OK;
+        return;
+    }
+    const uint8_t applied = (g_mod_force_readback < 0)
+                          ? wire_mod : (uint8_t)g_mod_force_readback;
+    out->status     = DOCK_MOD_APPLIED;
+    out->modulation = applied;
+    out->raw        = (g_mod_force_raw < 0) ? applied : (uint8_t)g_mod_force_raw;
+    out->flags      = g_mod_force_flags;
+}
+
+static const dock_hal_t HAL = {
+    hal_read, hal_write, hal_send, NULL, hal_tx, hal_set_vfo, hal_set_modulation
+};
 /* A build with no radio-side binding at all — 0x0873 must still answer. */
-static const dock_hal_t HAL_NO_VFO = { hal_read, hal_write, hal_send, NULL, hal_tx, NULL };
+static const dock_hal_t HAL_NO_VFO = {
+    hal_read, hal_write, hal_send, NULL, hal_tx, NULL, hal_set_modulation
+};
+/* A build carrying the set-VFO binding but not the set-modulation one — an F6
+ * firmware's shape. 0x0877 must still answer, with ERR_NO_HAL. */
+static const dock_hal_t HAL_NO_MOD = {
+    hal_read, hal_write, hal_send, NULL, hal_tx, hal_set_vfo, NULL
+};
 
 /* Decode the one 0x0874 reply in the capture buffer. False unless exactly one
  * well-formed reply is there, so "sent nothing" can never read as a pass. */
@@ -131,6 +175,25 @@ static bool last_vfo_reply(dock_vfo_applied_t *out)
     return true;
 }
 
+/* Decode the one 0x0878 reply in the capture buffer. Same "exactly one well-formed
+ * frame or false" rule as last_vfo_reply — silence must never read as a pass. */
+#define MOD_REPLY_FRAME_LEN 16u   /* AB CD | size:2 | (4 + 4 + 2) | DC BA */
+
+static bool last_mod_reply(dock_mod_applied_t *out)
+{
+    if (g_caplen != MOD_REPLY_FRAME_LEN) return false;
+    uint8_t body[4 + 4 + 2];
+    memcpy(body, g_cap + 4, sizeof(body));
+    dock_obfuscate(body, (uint16_t)sizeof(body));
+    if ((uint16_t)(body[0] | (body[1] << 8)) != DOCK_REPLY_SET_MOD) return false;
+    if ((uint16_t)(body[2] | (body[3] << 8)) != 4u) return false;
+    out->status     = body[4];
+    out->modulation = body[5];
+    out->raw        = body[6];
+    out->flags      = body[7];
+    return true;
+}
+
 static dock_ctx_t ctx;
 
 static void reset(void)
@@ -140,6 +203,10 @@ static void reset(void)
     g_tx_calls = 0; g_tx_last = -1; g_evn = 0; memset(g_ev, 0, sizeof(g_ev));
     g_vfo_calls = 0; memset(&g_vfo_last, 0, sizeof(g_vfo_last));
     g_vfo_force_status = DOCK_VFO_APPLIED;
+    g_mod_calls = 0; g_mod_last = 0xEE;
+    g_mod_force_status = DOCK_MOD_APPLIED;
+    g_mod_force_readback = -1; g_mod_force_raw = -1;
+    g_mod_force_flags = DOCK_MOD_FLAG_TX_OK;
     dock_init(&ctx, &HAL);
 }
 
@@ -572,6 +639,252 @@ int main(void)
     CHECK(last_vfo_reply(&rep) && rep.status == DOCK_VFO_ERR_TONE
           && rep.rx_hz == 0 && rep.ctcss_tenths == 0,
           "0x0874: an unresolvable tone refuses the whole tune, on frequency or not");
+
+    /* ================= 0x0877 set-modulation / 0x0878 (F7) ================= */
+
+    dock_mod_applied_t mrep;
+    static const uint8_t MOD_AM[1] = { DOCK_MOD_AM };
+
+    /* 25. Byte-exact COMMAND vector. Not a test of dock.c's dispatch — it exercises
+     *     this file's own builder — but it is the artifact a third-party client is
+     *     implemented against, and the thing that catches a client which mis-sizes
+     *     param_len, byte-swaps the opcode, or CRCs the obfuscated bytes instead of
+     *     the plaintext. Cross-checked against a separately written framer that
+     *     reproduces PROTOCOL.md's published 0x0951 and 0x0874 vectors exactly. */
+    reset();
+    {
+        static const uint8_t golden[] = {
+            0xAB, 0xCD, 0x05, 0x00,
+            0x61, 0x64, 0x15, 0xE6, 0x2F, 0x11, 0xD5,
+            0xDC, 0xBA,
+        };
+        flen = build_cmd(frame, DOCK_CMD_SET_MODULATION, MOD_AM, sizeof(MOD_AM));
+        CHECK(flen == sizeof(golden), "0x0877: golden command length");
+        CHECK(flen == sizeof(golden) && memcmp(frame, golden, sizeof(golden)) == 0,
+              "0x0877: byte-exact command vector");
+    }
+
+    /* 26. Byte-exact REPLY vector, the oracle radio-server's decoder is written
+     *     against. AM applies but cannot transmit on this build, so flags = 0 —
+     *     which is exactly the case a host most needs to read correctly. */
+    reset();
+    g_mod_force_flags = 0;                       /* AM: the radio will not key */
+    flen = build_cmd(frame, DOCK_CMD_SET_MODULATION, MOD_AM, sizeof(MOD_AM));
+    feed(frame, flen);
+    {
+        static const uint8_t golden[] = {
+            0xAB, 0xCD, 0x08, 0x00,
+            0x6E, 0x64, 0x10, 0xE6, 0x2E, 0x90, 0x0C, 0x40, 0xDE, 0xCA,
+            0xDC, 0xBA,
+        };
+        CHECK(g_caplen == sizeof(golden), "0x0878: golden reply length");
+        CHECK(g_caplen == sizeof(golden) &&
+              memcmp(g_cap, golden, sizeof(golden)) == 0,
+              "0x0878: byte-exact reply vector");
+    }
+
+    /* 27. A truncated payload is refused before params[0] is ever read. This is
+     *     what makes an EMPTY 0x0877 a safe firmware-level probe: the length check
+     *     is the first branch, so the frame cannot move the radio, and any 0x0878
+     *     at all answers "this firmware is F7 or later". */
+    reset();
+    flen = build_cmd(frame, DOCK_CMD_SET_MODULATION, params, 0);
+    feed(frame, flen);
+    CHECK(g_mod_calls == 0, "0x0877: an empty payload is refused, not read past");
+    CHECK(last_mod_reply(&mrep) && mrep.status == DOCK_MOD_ERR_SHORT,
+          "0x0878: a short payload is REPORTED, so the probe gets an answer");
+    CHECK(mrep.modulation == DOCK_MOD_UNKNOWN && mrep.raw == DOCK_MOD_UNKNOWN,
+          "0x0878: a refusal names no modulation — 0xFF, never 0 (0 is FM)");
+
+    /* 28. Out of range is refused, never clamped. USB's number is reserved but the
+     *     value is not accepted at F7, and 0x09 is not a modulation at all. A clamp
+     *     would leave the radio demodulating something nobody asked for while the
+     *     reply said it worked. */
+    reset();
+    {
+        uint8_t v[1] = { DOCK_MOD_USB };
+        flen = build_cmd(frame, DOCK_CMD_SET_MODULATION, v, sizeof(v));
+        feed(frame, flen);
+    }
+    CHECK(g_mod_calls == 0, "0x0877: reserved-but-unaccepted USB is refused");
+    CHECK(last_mod_reply(&mrep) && mrep.status == DOCK_MOD_ERR_FIELD,
+          "0x0878: USB refusal is named");
+
+    reset();
+    {
+        uint8_t v[1] = { 0x09 };
+        flen = build_cmd(frame, DOCK_CMD_SET_MODULATION, v, sizeof(v));
+        feed(frame, flen);
+    }
+    CHECK(g_mod_calls == 0, "0x0877: nonsense is refused, not folded into range");
+    CHECK(last_mod_reply(&mrep) && mrep.status == DOCK_MOD_ERR_FIELD
+          && mrep.modulation == DOCK_MOD_UNKNOWN,
+          "0x0878: an off-scale value refuses and names no modulation");
+
+    /* 29. Refused inside full-control, for the same reason 0x0873 is: applying it
+     *     would run RADIO_SetupRegisters underneath a host that believes it owns
+     *     the synthesiser. Ordering matters — SHORT is checked before BUSY, and
+     *     BUSY before the value — so a caller learns the most fundamental problem
+     *     first rather than the last one to be looked at. */
+    reset();
+    flen = build_cmd(frame, DOCK_CMD_ENTER_HW, params, 0); feed(frame, flen);
+    g_caplen = 0;
+    flen = build_cmd(frame, DOCK_CMD_SET_MODULATION, MOD_AM, sizeof(MOD_AM));
+    feed(frame, flen);
+    CHECK(g_mod_calls == 0, "0x0877: refused while the host holds full-control");
+    CHECK(last_mod_reply(&mrep) && mrep.status == DOCK_MOD_ERR_BUSY,
+          "0x0878: full-control is named, so the caller can retry after 0x0871");
+
+    flen = build_cmd(frame, DOCK_CMD_EXIT_HW, params, 0); feed(frame, flen);
+    g_caplen = 0;
+    flen = build_cmd(frame, DOCK_CMD_SET_MODULATION, MOD_AM, sizeof(MOD_AM));
+    feed(frame, flen);
+    CHECK(g_mod_calls == 1, "0x0877: accepted once full-control is released");
+    CHECK(last_mod_reply(&mrep) && mrep.status == DOCK_MOD_APPLIED,
+          "0x0878: applied after full-control is released");
+
+    /* 30. A REFUSAL MUST NOT MOVE THE STICKY VALUE. The single most important case
+     *     here. Set AM (applied), hold full-control, ask for FM (refused BUSY),
+     *     release, then tune — the tune must still carry AM. If the sticky value
+     *     were committed during decode rather than after the radio actually took
+     *     it, that refused FM would silently become what every later 0x0873
+     *     applies: the exact silent-revert bug this mechanism removes, in mirror
+     *     image, and invisible because the refusal itself was reported correctly. */
+    reset();
+    flen = build_cmd(frame, DOCK_CMD_SET_MODULATION, MOD_AM, sizeof(MOD_AM));
+    feed(frame, flen);
+    CHECK(last_mod_reply(&mrep) && mrep.status == DOCK_MOD_APPLIED,
+          "0x0878: AM applied (sticky-refusal setup)");
+
+    g_caplen = 0;
+    flen = build_cmd(frame, DOCK_CMD_ENTER_HW, params, 0); feed(frame, flen);
+    {
+        uint8_t v[1] = { DOCK_MOD_FM };
+        g_caplen = 0;
+        flen = build_cmd(frame, DOCK_CMD_SET_MODULATION, v, sizeof(v));
+        feed(frame, flen);
+    }
+    CHECK(last_mod_reply(&mrep) && mrep.status == DOCK_MOD_ERR_BUSY,
+          "0x0878: the FM request is refused while full-control is held");
+
+    flen = build_cmd(frame, DOCK_CMD_EXIT_HW, params, 0); feed(frame, flen);
+    g_caplen = 0;
+    flen = build_cmd(frame, DOCK_CMD_SET_VFO, K0PRA, sizeof(K0PRA));
+    feed(frame, flen);
+    CHECK(g_vfo_last.modulation == DOCK_MOD_AM,
+          "0x0873: a REFUSED set-modulation never became the sticky value");
+
+    /* 31. A valid frame reaches the binding exactly once, and does nothing else.
+     *     NOTE: this stays green against a stub that skips every check — it
+     *     discriminates against a dispatch that never calls the binding or calls it
+     *     twice, not against one that fails to validate. Do not read it as evidence
+     *     the refusals work; that is what 27-30 are for. */
+    reset();
+    flen = build_cmd(frame, DOCK_CMD_SET_MODULATION, MOD_AM, sizeof(MOD_AM));
+    feed(frame, flen);
+    CHECK(g_mod_calls == 1 && g_mod_last == DOCK_MOD_AM,
+          "0x0877: a valid frame reaches the binding exactly once, with the value sent");
+    CHECK(g_writes == 0 && g_reads == 0 && g_vfo_calls == 0,
+          "0x0877: no register traffic and no set-VFO of its own");
+    CHECK(g_tx_calls == 0 && !ctx.tx_on, "0x0877: no PA activity of its own");
+
+    /* 32. THE POINT OF THE STICKY VALUE. Set AM, then tune — the tune must carry
+     *     AM into the binding. Without this, uart.c's Dock_ApplyVfo writes
+     *     MODULATION_FM literally and a tune silently undoes the modulation, with
+     *     nothing on the wire saying so. Sending the two as separate frames is not
+     *     just awkward, it is unreliable: this link drops frames (ADR 0131), so a
+     *     dropped set-modulation after a tune leaves the radio on the right channel
+     *     in the wrong demodulator. */
+    reset();
+    flen = build_cmd(frame, DOCK_CMD_SET_MODULATION, MOD_AM, sizeof(MOD_AM));
+    feed(frame, flen);
+    g_caplen = 0;
+    flen = build_cmd(frame, DOCK_CMD_SET_VFO, K0PRA, sizeof(K0PRA));
+    feed(frame, flen);
+    CHECK(g_vfo_calls == 1 && g_vfo_last.modulation == DOCK_MOD_AM,
+          "0x0873: carries the modulation 0x0877 set, so a tune cannot revert it");
+    CHECK(last_vfo_reply(&rep) && rep.status == DOCK_VFO_APPLIED,
+          "0x0874: the tune still applies normally with a sticky modulation");
+
+    /* 33. Backward compatibility, stated as a test. A host that never sends 0x0877
+     *     must see F6 behaviour exactly — so the sticky value is seeded FM, from a
+     *     constant. Seeding it by reading the radio's current modulation would pass
+     *     this only by luck and would be the ADR 0132 "adopt whatever state you
+     *     find" fault: a repeater channel tuned in whatever the front panel was
+     *     last left on. */
+    reset();
+    flen = build_cmd(frame, DOCK_CMD_SET_VFO, K0PRA, sizeof(K0PRA));
+    feed(frame, flen);
+    CHECK(g_vfo_calls == 1 && g_vfo_last.modulation == DOCK_MOD_FM,
+          "0x0873: FM without a prior 0x0877 — an F6 host sees no change at all");
+
+    /* 34. The reply REPORTS, it does not ECHO. The fake is told to come back with
+     *     FM after being asked for AM; the reply must say FM while the sticky value
+     *     holds the AM that was requested and accepted. This is the 0x0874 `power`
+     *     bug in a new field: the wire's "high" landed on OUTPUT_POWER_LOW2 and a
+     *     reply that echoed the request would have confirmed it perfectly. */
+    reset();
+    g_mod_force_readback = DOCK_MOD_FM;
+    g_mod_force_raw      = 0;
+    flen = build_cmd(frame, DOCK_CMD_SET_MODULATION, MOD_AM, sizeof(MOD_AM));
+    feed(frame, flen);
+    CHECK(last_mod_reply(&mrep) && mrep.status == DOCK_MOD_APPLIED
+          && mrep.modulation == DOCK_MOD_FM,
+          "0x0878: reports the read-back, not the value it was handed");
+    CHECK(ctx.modulation == DOCK_MOD_AM,
+          "0x0877: the sticky value is the accepted request, reported independently");
+
+    /* 35. A modulation the wire cannot name survives as UNKNOWN. On a build with
+     *     ENABLE_BYP_RAW_DEMODULATORS the radio has modes this protocol has no word
+     *     for, and the firmware enum's numbering shifts underneath them. Collapsing
+     *     one onto index 0 would report FM — a specific, wrong, believable answer.
+     *     `raw` still carries the radio's own value, which is the only thing that
+     *     can tell BYP from RAW at a bench at 2 a.m. */
+    reset();
+    g_mod_force_readback = DOCK_MOD_UNKNOWN;
+    g_mod_force_raw      = 3;                    /* MODULATION_BYP on such a build */
+    flen = build_cmd(frame, DOCK_CMD_SET_MODULATION, MOD_AM, sizeof(MOD_AM));
+    feed(frame, flen);
+    CHECK(last_mod_reply(&mrep) && mrep.status == DOCK_MOD_APPLIED
+          && mrep.modulation == DOCK_MOD_UNKNOWN && mrep.raw == 3,
+          "0x0878: an unnameable modulation stays UNKNOWN and keeps its raw value");
+
+    /* 36. An F6-shaped build — set-VFO bound, set-modulation not — still answers.
+     *     Silence is what a pre-F7 firmware does, and it is how a host detects the
+     *     level; a firmware that HAS the opcode but no binding must not imitate it. */
+    reset();
+    dock_init(&ctx, &HAL_NO_MOD);
+    flen = build_cmd(frame, DOCK_CMD_SET_MODULATION, MOD_AM, sizeof(MOD_AM));
+    feed(frame, flen);
+    CHECK(g_caplen == MOD_REPLY_FRAME_LEN, "0x0878: a missing binding still replies");
+    CHECK(last_mod_reply(&mrep) && mrep.status == DOCK_MOD_ERR_NO_HAL,
+          "0x0878: a missing set_modulation binding is reported, not silent");
+
+    /* 37. A rejection never describes a modulation — enforced in dock.c, not left
+     *     to each binding. The fake writes FM and TX_OK on its refusal on purpose.
+     *     Blanking to 0 here (0x0874 blanks its frequencies to 0) would answer
+     *     "refused, and by the way you are on FM, and you can transmit" — which is
+     *     worse than 0x0874's case, because 0 Hz is obviously not a channel and 0
+     *     IS a valid modulation. */
+    reset();
+    g_mod_force_status = DOCK_MOD_ERR_FIELD;
+    flen = build_cmd(frame, DOCK_CMD_SET_MODULATION, MOD_AM, sizeof(MOD_AM));
+    feed(frame, flen);
+    CHECK(last_mod_reply(&mrep) && mrep.status == DOCK_MOD_ERR_FIELD,
+          "0x0878: a refusal from the radio side is reported");
+    CHECK(mrep.modulation == DOCK_MOD_UNKNOWN && mrep.raw == DOCK_MOD_UNKNOWN
+          && mrep.flags == 0,
+          "0x0878: a non-zero status ships no modulation and no TX claim, whatever the HAL wrote");
+
+    /* 38. An unknown opcode is still answered with silence. This is not a detail —
+     *     it is the whole firmware-level detection mechanism: a new host sending
+     *     0x0877 to a pre-F7 radio must get nothing back, so "no reply" means "does
+     *     not have it". A default: that started replying would break every level
+     *     probe at once, including 0x0873's. */
+    reset();
+    flen = build_cmd(frame, 0x087Fu, MOD_AM, sizeof(MOD_AM));
+    feed(frame, flen);
+    CHECK(g_caplen == 0, "unknown opcode: still no reply, so absence stays detectable");
 
     /* ---- report ---- */
     printf("dock host tests: %d checks, %d failures\n", g_checks, g_fail);


### PR DESCRIPTION
Adds `0x0877` set-modulation and its `0x0878` reply — **F7**. FM and AM. Reasoning lives in radio-server [ADR 0149](https://github.com/kbennett2000/radio-server/pull/206), per AGENTS.md.

## `0x0877`, not `0x0875`

radio-server's ADR 0111:52 records the classic Dock's full-control extras as *"0x0872 modulation, **0x0873/4 backlight, 0x0875/6 AM emulation**"*. nicsure's source is not vendored here so that census cannot be re-verified — per guardrail 1 it is treated as **claimed**, not free-until-proven.

Reading it turned up something worse: **`0x0873/4` is on the same list**, and it was allocated after ruling out `0x0872` alone. That one is shipped, on hardware, in a cut release. It cannot be walked back. This one was cheap to place correctly, so it was. `PROTOCOL.md` now tells the next implementer to check the census before allocating.

## A new opcode, not a 14th byte on `0x0873`

A field appended there changes bytes on a frame radio-server already sends and breaks **both** directions **silently** — an old host's 13-byte frame is refused `ERR_SHORT` and reads as a tuning failure; a new host's 14-byte frame decodes fine on old firmware, which then tunes on a modulation nobody set. A new opcode is additive: an old host never sends it, a new host gets silence from firmware that lacks it. **An empty `0x0877` is the F7 probe**, safe because the length check is the first branch.

## The modulation is sticky, and `0x0873` applies it

Not a convenience. **This link drops frames** (ADR 0131 — single-threaded firmware, anything arriving while it is busy is discarded, not queued), so "tune, then set modulation" as two frames can leave the radio on the right channel in the wrong demodulator with nothing on the wire saying so.

- **Seeded FM from a constant**, never read back off the radio — that is the "adopt whatever state you find" fault (ADR 0132), and would tune a repeater channel in whatever the front panel was last left on. A host that never sends `0x0877` sees F6 behaviour exactly.
- **A refusal never moves it.** Committing during decode would let a refused request silently become what every later tune applies — the same bug in mirror image, and invisible because the refusal itself was reported correctly.
- **`0x0873`'s wire bytes are untouched.** One literal at `uart.c:850` became a table lookup whose default is that literal.

## `0x0878` reports what the radio is on — and whether it can still transmit

Read back out of the radio's VFO after applying, not echoed, plus the radio's own raw enum value. **On any non-zero status both are `0xFF`, not `0`** — `0x0874` blanks frequencies to zero because 0 Hz is obviously not a channel, but **`0` is FM**, so copying that would answer a refusal with a plausible claim about where the radio is. The one place a literal copy of the existing code produces a shipped bug.

And a **flags** byte, because a successful set-AM stops the transmitter: without `ENABLE_TX_WHEN_AM` (this tree is not built with it) `RADIO_PrepareTX` refuses any non-FM modulation, and that is the path the radio's **PTT pin** drives — where radio-server's `baofeng` backend keys from via the AIOC's DTR line. Dock REG_30 keying bypasses it, so the same state means "cannot transmit" on one backend and "transmits normally" on another. **The flag reports the condition; it does not remove it. AM stays receive-only.**

## The wire names its own values

`ModulationMode_t`'s numeric end **moves with `ENABLE_BYP_RAW_DEMODULATORS`**, so a wire bound derived from it means different things in two builds of the same protocol. `uart.c` maps both ways: in, a `_Static_assert`'d designated-initialiser table; out, a `switch` with a `default`, because an array indexed by that enum reads off its own end on exactly the build where the extra members exist. `DOCK_POWER_MAP`'s lesson applied before it bites.

USB's **number** is reserved; its **value** is refused. Nobody has put this radio on USB at a bench, it cannot transmit in it anyway, and accepting it later is purely additive.

## Fail-first — run against the bug, twice

| Build | Result |
|---|---|
| Stub: always reports success, echoes the request, commits the sticky value unconditionally | **98 checks, 15 failures** |
| Correct command, but `0x0873` keeps its `MODULATION_FM` hardcode | **98 checks, 2 failures** — exactly the two stickiness cases |
| This branch | **98 checks, 0 failures** (66 before) |

The second run is the one that matters: it fails only what it should, so green on the real build means something.

- The byte-exact **`0x0874` golden stays green** — that is the gate on `0x0873`'s wire being untouched.
- New goldens came from a **separately written framer** validated by reproducing `PROTOCOL.md`'s published `0x0951` and `0x0874` vectors byte-for-byte first. A vector produced by the implementation it checks is a transcript, not an oracle.
- Two tests are commented to say they **stay green against the stub** (31 "reaches the binding once", 33 "F6 compatibility") so nobody later cites them as proof the refusals work.

## Lockout: confirmed no

`gSerialConfigCountDown_500ms` is armed at exactly four sites — `CMD_0514`, `CMD_051B`, `CMD_051D`, `CMD_052F` — none reachable from the dock dispatch, and it appears nowhere else in `App/` but its declaration, definition, the scheduler decrement and `SerialConfigInProgress()`. The only post-switch statement in `UART_HandleCommand` is `gUART_LockK5Viewer`, which suppresses telemetry.

## Size

**FLASH 105,576 B of 118 KB (87.37%)**, +240 B over F6's 105,336. Headroom 15,256 B. RAM unchanged at 13,088 B (79.88%).

## Also fixed

`dock.h`'s module docstring still claimed the module has **no modulation commands** and had never mentioned `0x0873`. The `⚠ CONFIRM AT BENCH` counts in `BENCH.md` ("four") and `AGENTS.md` ("five", while naming four) disagreed with each other before this cycle added to them — both now describe the items instead of counting them.

## Not claimed

**Not flashed. No hardware result.** AM audio over the AIOC and the PTT refusal are new `⚠ CONFIRM AT BENCH` items in `BENCH.md`, left as placeholders (guardrail 1). The F7 pre-release's `PROVENANCE.md` will say so rather than carrying F6's measured-on-hardware paragraph forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)