### PR TITLE
Add SuperF action (discussion #501)

### DIFF
--- a/App/CMakeLists.txt
+++ b/App/CMakeLists.txt
@@ -214,6 +214,9 @@ enable_feature(ENABLE_FEAT_F4HWN_RXTX_LOG
 enable_feature(ENABLE_FEAT_F4HWN_FOXHUNT
     app/foxhunt.c
 )
+enable_feature(ENABLE_SUPERF
+    app/superf.c
+)
 enable_feature(ENABLE_FEAT_F4HWN_RXTX_LOG_WRAP)
 enable_feature(ENABLE_FEAT_F4HWN_RXTX_LOG_K5VIEWER)
 

--- a/App/app/action.c
+++ b/App/app/action.c
@@ -48,6 +48,9 @@
 #ifdef ENABLE_FEAT_F4HWN_RXTX_LOG
     #include "app/rxtx_log.h"
 #endif
+#ifdef ENABLE_SUPERF
+    #include "app/superf.h"
+#endif
 #ifdef ENABLE_FEAT_F4HWN_FOXHUNT
     #include "app/foxhunt.h"
 #endif
@@ -142,6 +145,9 @@ void (*const action_opt_table[])(void) = {
 #endif
 #ifdef ENABLE_FEAT_F4HWN_FOXHUNT
     [ACTION_OPT_FOXHUNT] = &ACTION_FoxHunt,
+#endif
+#ifdef ENABLE_SUPERF
+    [ACTION_OPT_SUPERF] = &ACTION_SuperF,
 #endif
 };
 
@@ -392,6 +398,9 @@ void ACTION_Handle(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
     #ifdef ENABLE_FEAT_F4HWN_FOXHUNT
             case ACTION_OPT_FOXHUNT:
     #endif
+    #ifdef ENABLE_SUPERF
+            case ACTION_OPT_SUPERF:
+    #endif
                 gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
                 return;
 
@@ -400,7 +409,10 @@ void ACTION_Handle(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
         }
     }
 #endif
-
+#ifdef ENABLE_SUPERF
+    if(gSuperFActive)
+        func = ACTION_OPT_NONE;
+#endif
     action_opt_table[func]();
 }
 

--- a/App/app/action.h
+++ b/App/app/action.h
@@ -55,6 +55,10 @@ void ACTION_SwitchDemodul(void);
     #endif
 #endif
 
+#ifdef ENABLE_SUPERF
+    extern void (*const action_opt_table[])(void);
+#endif
+
 void ACTION_Handle(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld);
 
 #endif

--- a/App/app/app.c
+++ b/App/app/app.c
@@ -42,6 +42,9 @@
 #ifdef ENABLE_FEAT_F4HWN_RXTX_LOG
     #include "app/rxtx_log.h"
 #endif
+#ifdef ENABLE_SUPERF
+    #include "app/superf.h"
+#endif
 #include "app/scanner.h"
 #if defined(ENABLE_UART) || defined(ENABLE_USB)
     #include "app/uart.h"
@@ -122,6 +125,10 @@ void (*const ProcessKeysFunctions[])(KEY_Code_t Key, bool bKeyPressed, bool bKey
 
 #ifdef ENABLE_FEAT_F4HWN_RXTX_LOG
     [DISPLAY_RXTX_LOG] = &RXTX_LOG_ProcessKeys,
+#endif
+
+#ifdef ENABLE_SUPERF
+    [DISPLAY_SUPERF] = &SuperF_ProcessKeys,
 #endif
 };
 
@@ -2346,7 +2353,7 @@ static void ProcessKey(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
         }
         // KEY_MENU has a special treatment here, because we want to pass hold event to ACTION_Handle
         // but we don't want it to complain when initial press happens
-        // we want to react on realese instead
+        // we want to react on release instead
         else if (!passActionKey)
         {
             if ((!bKeyPressed || bKeyHeld || (Key == KEY_MENU && bKeyPressed)) && // prevent released or held, prevent KEY_MENU pressed

--- a/App/app/superf.c
+++ b/App/app/superf.c
@@ -1,0 +1,97 @@
+/* Copyright 2026 Armel F4HWN
+ * https://github.com/armel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+
+#include "superf.h"
+
+#ifdef ENABLE_SUPERF
+
+#include "misc.h"
+#include "audio.h"
+#include "ui/ui.h"
+#include "ui/menu.h"
+#include "ui/helper.h"
+#include "action.h"
+#include "external/printf/printf.h"
+#include "settings.h"
+#include <assert.h>
+#include <string.h>
+
+bool gSuperFActive = 0;
+uint8_t gCurrentSuperFIndex = 1;
+
+static void SuperF_KeyExit(void)
+{
+    GUI_SelectNextDisplay(DISPLAY_MAIN);
+    gSuperFActive = false;
+}
+
+static void SuperF_KeyMenu(void)
+{
+    SuperF_KeyExit();
+    gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
+    action_opt_table[gSubMenu_SIDEFUNCTIONS[gCurrentSuperFIndex].id]();
+}
+
+void ACTION_SuperF(void)
+{
+    gSuperFActive = true; // useless?
+    GUI_SelectNextDisplay(DISPLAY_SUPERF);
+}
+
+void SuperF_ProcessKeys(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
+{
+    if (!bKeyPressed && Key != KEY_MENU)
+        return;
+
+    if (Key != KEY_MENU)
+        gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
+
+    switch (Key) {
+    case KEY_UP:
+        gCurrentSuperFIndex = (gCurrentSuperFIndex >= gSubMenu_SIDEFUNCTIONS_size - 1)? 1 : gCurrentSuperFIndex + 1;
+        break;
+    case KEY_DOWN:
+        gCurrentSuperFIndex = (gCurrentSuperFIndex <= 1)? gSubMenu_SIDEFUNCTIONS_size - 1 : gCurrentSuperFIndex - 1;
+        break;
+    case KEY_MENU:
+        if (!bKeyPressed)
+            SuperF_KeyMenu();
+        break;
+    case KEY_EXIT:
+        SuperF_KeyExit();
+        return;
+    default:
+        gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
+        break;
+    }
+
+    gUpdateDisplay = true;
+}
+
+void UI_DisplaySuperF(void)
+{
+    UI_DisplayClear();
+    char* message = "--Choose action--";
+    char index[16];
+    sprintf(index, "%u", gCurrentSuperFIndex);
+    UI_PrintStringSmallNormal(message, 0, 127, 0);
+    UI_PrintStringSmallNormal(gSubMenu_SIDEFUNCTIONS[(gCurrentSuperFIndex >= gSubMenu_SIDEFUNCTIONS_size - 1)? 1 : gCurrentSuperFIndex + 1].name, 0, 127, 2);
+    UI_PrintString(gSubMenu_SIDEFUNCTIONS[gCurrentSuperFIndex].name, 0, 127, 3, 8);
+    UI_PrintStringSmallNormal(gSubMenu_SIDEFUNCTIONS[(gCurrentSuperFIndex <= 1)? gSubMenu_SIDEFUNCTIONS_size - 1 : gCurrentSuperFIndex - 1].name, 0, 127, 5);
+    ST7565_BlitFullScreen();
+}
+
+#endif // ENABLE_SUPERF

--- a/App/app/superf.c
+++ b/App/app/superf.c
@@ -22,6 +22,7 @@
 #include "audio.h"
 #include "ui/ui.h"
 #include "ui/menu.h"
+#include "ui/inputbox.h"
 #include "ui/helper.h"
 #include "action.h"
 #include "external/printf/printf.h"
@@ -45,6 +46,25 @@ static void SuperF_KeyMenu(void)
     action_opt_table[gSubMenu_SIDEFUNCTIONS[gCurrentSuperFIndex].id]();
 }
 
+static void SuperF_Key_DIGITS(KEY_Code_t Key)
+{
+    INPUTBOX_Append(Key);
+
+    uint8_t index = StrToUL(INPUTBOX_GetAscii());
+
+    if (index < gSubMenu_SIDEFUNCTIONS_size-1) 
+        gCurrentSuperFIndex = index+1;
+    else
+    {
+        gInputBoxIndex--;
+        gInputBox[0] = gInputBox[1];
+        gCurrentSuperFIndex = gInputBox[0]+1;
+    }
+    
+    if (gInputBoxIndex >= 2)
+        gInputBoxIndex = 0;
+}
+
 void ACTION_SuperF(void)
 {
     gSuperFActive = true; // useless?
@@ -60,6 +80,9 @@ void SuperF_ProcessKeys(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
         gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
 
     switch (Key) {
+    case KEY_0...KEY_9:
+        SuperF_Key_DIGITS(Key);
+        break;
     case KEY_UP:
         gCurrentSuperFIndex = (gCurrentSuperFIndex >= gSubMenu_SIDEFUNCTIONS_size - 1)? 1 : gCurrentSuperFIndex + 1;
         break;

--- a/App/app/superf.h
+++ b/App/app/superf.h
@@ -1,0 +1,37 @@
+/* Copyright 2026 Armel F4HWN
+ * https://github.com/armel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+
+#ifndef APP_SUPERF_H
+#define APP_SUPERF_H
+
+#ifdef ENABLE_SUPERF
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "driver/keyboard.h"
+#include "driver/st7565.h"
+#include "driver/system.h"
+
+extern bool          gSuperFActive;
+extern uint8_t       gCurrentSuperFIndex;
+
+void ACTION_SuperF(void);
+void SuperF_ProcessKeys(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld);
+void UI_DisplaySuperF(void);
+
+#endif // ENABLE_SUPERF
+#endif // APP_SUPERF_H

--- a/App/settings.h
+++ b/App/settings.h
@@ -136,6 +136,10 @@ enum ACTION_OPT_t {
 #ifdef ENABLE_FEAT_F4HWN_FOXHUNT
     ACTION_OPT_FOXHUNT,
 #endif
+#ifdef ENABLE_SUPERF
+    ACTION_OPT_SUPERF,
+#endif
+
     ACTION_OPT_LEN
 };
 

--- a/App/ui/menu.c
+++ b/App/ui/menu.c
@@ -528,6 +528,9 @@ const t_sidefunction gSubMenu_SIDEFUNCTIONS[] =
     #ifdef ENABLE_FEAT_F4HWN_FOXHUNT
         {"FOX HUNT\nBEACON", ACTION_OPT_FOXHUNT},
     #endif
+    #ifdef ENABLE_SUPERF
+        {"SuperF", ACTION_OPT_SUPERF},
+    #endif
 #endif
 };
 

--- a/App/ui/ui.c
+++ b/App/ui/ui.c
@@ -33,6 +33,9 @@
 #ifdef ENABLE_FEAT_F4HWN_RXTX_LOG
     #include "app/rxtx_log.h"
 #endif
+#ifdef ENABLE_SUPERF
+    #include "app/superf.h"
+#endif
 #include "ui/inputbox.h"
 #include "ui/main.h"
 #include "ui/menu.h"
@@ -63,6 +66,10 @@ void (*const UI_DisplayFunctions[])(void) = {
 
 #ifdef ENABLE_FEAT_F4HWN_RXTX_LOG
     [DISPLAY_RXTX_LOG] = &UI_DisplayRxTxLog,
+#endif
+
+#ifdef ENABLE_SUPERF
+    [DISPLAY_SUPERF] = &UI_DisplaySuperF,
 #endif
 };
 

--- a/App/ui/ui.h
+++ b/App/ui/ui.h
@@ -38,6 +38,10 @@ enum GUI_DisplayType_t
     DISPLAY_RXTX_LOG,
 #endif
 
+#ifdef ENABLE_SUPERF
+    DISPLAY_SUPERF,
+#endif
+
     DISPLAY_N_ELEM,
     DISPLAY_INVALID = 0xFFu
 };

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -218,6 +218,7 @@
                 "ENABLE_FEAT_F4HWN_LOGO": true,
                 "ENABLE_FEAT_F4HWN_LOGO_SAV": true,
                 "ENABLE_FEAT_F4HWN_MENU_CAT": true,
+                "ENABLE_SUPERF": true,
                 "ENABLE_SWD": true,
                 "EDITION_STRING": "Fusion",
                 "TARGET": "f4hwn.fusion"


### PR DESCRIPTION
Hello, 

This PR adds a "SuperF" action, which is programmable on the side keys (F1/2 SHORT/LONG) or M LONG. When active, the user can go through the available actions (with KEY_UP/DOWN), and select an action with the MENU key (the action is triggered on release). The incentive behind this PR is the growing number of actions, as discussed in #501 (where a short video is available to illustrate this PR) , which forces users to make compromises. 

Feel free to give feedback; thank you