### PR TITLE
Flashlight button timeout convenience feature

### DIFF
--- a/App/app/flashlight.c
+++ b/App/app/flashlight.c
@@ -63,6 +63,14 @@ static inline void Flashlight_Toggle(){ GPIO_TogglePin(GPIO_PIN_FLASHLIGHT); }
         //         Flashlight_TurnOff();
         // }
 
+        if (gFlashLightButtonTimeout_10ms == 0 && gFlashLightState != FLASHLIGHT_OFF) {
+            Flashlight_TurnOff();
+	    gFlashLightState = FLASHLIGHT_OFF;
+	    return;
+        }
+        gFlashLightButtonTimeout_10ms = flashlight_button_countdown_10ms;
+
+
         if(gFlashLightState == FLASHLIGHT_OFF) {
             Flashlight_TurnOn();
         }

--- a/App/app/flashlight.c
+++ b/App/app/flashlight.c
@@ -65,8 +65,8 @@ static inline void Flashlight_Toggle(){ GPIO_TogglePin(GPIO_PIN_FLASHLIGHT); }
 
         if (gFlashLightButtonTimeout_10ms == 0 && gFlashLightState != FLASHLIGHT_OFF) {
             Flashlight_TurnOff();
-	        gFlashLightState = FLASHLIGHT_OFF;
-	        return;
+            gFlashLightState = FLASHLIGHT_OFF;
+            return;
         }
         gFlashLightButtonTimeout_10ms = flashlight_button_countdown_10ms;
 

--- a/App/app/flashlight.c
+++ b/App/app/flashlight.c
@@ -65,11 +65,10 @@ static inline void Flashlight_Toggle(){ GPIO_TogglePin(GPIO_PIN_FLASHLIGHT); }
 
         if (gFlashLightButtonTimeout_10ms == 0 && gFlashLightState != FLASHLIGHT_OFF) {
             Flashlight_TurnOff();
-	    gFlashLightState = FLASHLIGHT_OFF;
-	    return;
+	        gFlashLightState = FLASHLIGHT_OFF;
+	        return;
         }
         gFlashLightButtonTimeout_10ms = flashlight_button_countdown_10ms;
-
 
         if(gFlashLightState == FLASHLIGHT_OFF) {
             Flashlight_TurnOn();

--- a/App/app/flashlight.h
+++ b/App/app/flashlight.h
@@ -15,6 +15,9 @@
 
     extern enum FlashlightMode_t gFlashLightState;
     extern volatile uint16_t     gFlashLightBlinkCounter;
+    extern volatile uint8_t      gFlashLightButtonTimeout_10ms;
+
+    extern const uint8_t         flashlight_button_countdown_10ms; 
 
     void FlashlightTimeSlice(void);
 #endif

--- a/App/misc.c
+++ b/App/misc.c
@@ -85,6 +85,8 @@ const uint16_t    NOAA_countdown_10ms              =  5000 / 10;   // 5 seconds
 const uint16_t    NOAA_countdown_2_10ms            =   500 / 10;   // 500ms
 const uint16_t    NOAA_countdown_3_10ms            =   200 / 10;   // 200ms
 
+const uint8_t     flashlight_button_countdown_10ms =  2500 / 10;   // 2.5 seconds
+
 const uint32_t    gDefaultAesKey[4]                = {0x4AA5CC60, 0x0312CC5F, 0xFFD2DABB, 0x6BBA7F92};
 
 const uint8_t     gMicGain_dB2[9]                  = {3, 8, 16, 24, 32, 40, 48, 56, 63}; // BK4819 {3, 8, 16, 24, 31};
@@ -282,6 +284,7 @@ bool              g_CxCSS_TAIL_Found;
 bool              g_SquelchLost;
 
 volatile uint16_t gFlashLightBlinkCounter;
+volatile uint8_t  gFlashLightButtonTimeout_10ms;
 
 bool              gFlagEndTransmission;
 uint16_t          gNextMrChannel;

--- a/App/misc.c
+++ b/App/misc.c
@@ -85,7 +85,9 @@ const uint16_t    NOAA_countdown_10ms              =  5000 / 10;   // 5 seconds
 const uint16_t    NOAA_countdown_2_10ms            =   500 / 10;   // 500ms
 const uint16_t    NOAA_countdown_3_10ms            =   200 / 10;   // 200ms
 
-const uint8_t     flashlight_button_countdown_10ms =  2500 / 10;   // 2.5 seconds
+#if !defined(ENABLE_FEAT_F4HWN) || defined(ENABLE_FEAT_F4HWN_RESCUE_OPS)
+    const uint8_t     flashlight_button_countdown_10ms =  2500 / 10;   // 2.5 seconds
+#endif
 
 const uint32_t    gDefaultAesKey[4]                = {0x4AA5CC60, 0x0312CC5F, 0xFFD2DABB, 0x6BBA7F92};
 
@@ -283,8 +285,10 @@ bool              g_CxCSS_TAIL_Found;
 #endif
 bool              g_SquelchLost;
 
-volatile uint16_t gFlashLightBlinkCounter;
-volatile uint8_t  gFlashLightButtonTimeout_10ms;
+#if !defined(ENABLE_FEAT_F4HWN) || defined(ENABLE_FEAT_F4HWN_RESCUE_OPS)
+    volatile uint16_t gFlashLightBlinkCounter;
+    volatile uint8_t  gFlashLightButtonTimeout_10ms;
+#endif
 
 bool              gFlagEndTransmission;
 uint16_t          gNextMrChannel;

--- a/App/misc.h
+++ b/App/misc.h
@@ -125,7 +125,9 @@ extern const uint16_t        NOAA_countdown_10ms;
 extern const uint16_t        NOAA_countdown_2_10ms;
 extern const uint16_t        NOAA_countdown_3_10ms;
 
-extern const uint8_t         flashlight_button_countdown_10ms;
+#if !defined(ENABLE_FEAT_F4HWN) || defined(ENABLE_FEAT_F4HWN_RESCUE_OPS)
+    extern const uint8_t         flashlight_button_countdown_10ms;
+#endif
 
 extern const uint16_t        dual_watch_count_after_tx_10ms;
 extern const uint16_t        dual_watch_count_after_rx_10ms;
@@ -432,8 +434,10 @@ extern bool                  g_CxCSS_TAIL_Found;
 // true means we are receiving signal
 extern bool                  g_SquelchLost;
 
-extern volatile uint16_t     gFlashLightBlinkCounter;
-extern volatile uint8_t      gFlashLightButtonTimeout_10ms;
+#if !defined(ENABLE_FEAT_F4HWN) || defined(ENABLE_FEAT_F4HWN_RESCUE_OPS)
+    extern volatile uint16_t     gFlashLightBlinkCounter;
+    extern volatile uint8_t      gFlashLightButtonTimeout_10ms;
+#endif
 
 extern bool                  gFlagEndTransmission;
 extern uint16_t              gNextMrChannel;

--- a/App/misc.h
+++ b/App/misc.h
@@ -125,6 +125,8 @@ extern const uint16_t        NOAA_countdown_10ms;
 extern const uint16_t        NOAA_countdown_2_10ms;
 extern const uint16_t        NOAA_countdown_3_10ms;
 
+extern const uint8_t         flashlight_button_countdown_10ms;
+
 extern const uint16_t        dual_watch_count_after_tx_10ms;
 extern const uint16_t        dual_watch_count_after_rx_10ms;
 extern const uint16_t        dual_watch_count_after_1_10ms;
@@ -431,6 +433,7 @@ extern bool                  g_CxCSS_TAIL_Found;
 extern bool                  g_SquelchLost;
 
 extern volatile uint16_t     gFlashLightBlinkCounter;
+extern volatile uint8_t      gFlashLightButtonTimeout_10ms;
 
 extern bool                  gFlagEndTransmission;
 extern uint16_t              gNextMrChannel;

--- a/App/scheduler.c
+++ b/App/scheduler.c
@@ -132,6 +132,8 @@ void SysTick_Handler(void)
 
     DECREMENT_AND_TRIGGER(gTailNoteEliminationCountdown_10ms, gFlagTailNoteEliminationComplete);
 
+    DECREMENT(gFlashLightButtonTimeout_10ms);
+
 #ifdef ENABLE_VOICE
     DECREMENT_AND_TRIGGER(gCountdownToPlayNextVoice_10ms, gFlagPlayQueuedVoice);
 #endif

--- a/App/scheduler.c
+++ b/App/scheduler.c
@@ -132,7 +132,9 @@ void SysTick_Handler(void)
 
     DECREMENT_AND_TRIGGER(gTailNoteEliminationCountdown_10ms, gFlagTailNoteEliminationComplete);
 
+#if !defined(ENABLE_FEAT_F4HWN) || defined(ENABLE_FEAT_F4HWN_RESCUE_OPS)
     DECREMENT(gFlashLightButtonTimeout_10ms);
+#endif
 
 #ifdef ENABLE_VOICE
     DECREMENT_AND_TRIGGER(gCountdownToPlayNextVoice_10ms, gFlagPlayQueuedVoice);


### PR DESCRIPTION
After using the flashlight in any mode for more than a moment it's expected that you'd want to turn it off instead of cycling through the rest of the blinking modes. This code adds 2.5s timeout after which a flashlight action would turn off the flashlight instead of cycling the rest of the modes.

This code adds 60 bytes of flash usage.

I'm thinking do we want similar behavior for channel name text input, so the text editor goes to next character after some time, and/or when switching to a  different key button on the keypad?