### PR TITLE
Fix RSSI level line overlapping BW text in spectrum

### DIFF
--- a/App/app/spectrum.c
+++ b/App/app/spectrum.c
@@ -1733,17 +1733,23 @@ static uint8_t GetScanStepTextWidth()
     return (sprintf(NULL, "%u", GetScanStep() / 100) + 4) * 4; // "%u.%02uk", 4 px advance per char
 }
 
+static uint8_t GetBwTextWidth()
+{
+    return (strlen(bwOptions[settings.listenBw]) * 4) + 4; // 4 px advance per char
+}
+
 static void DrawRssiTriggerLevel(const uint8_t *topY)
 {
     if (settings.rssiTriggerLevel == RSSI_MAX_VALUE || monitorMode)
         return;
     uint8_t scanStepTextWidth = GetScanStepTextWidth();
+    uint8_t bwTextWidth = GetBwTextWidth();
     uint8_t y = Rssi2Y(settings.rssiTriggerLevel);
     for (uint8_t x = 0; x < 128; x += 2)
     {
         if (SpectrumColumnAtOrAboveY(topY, x, y))
             continue;
-        if (y <= 12 && (x < scanStepTextWidth + 2 || x >= 114))
+        if (y <= 12 && (x < scanStepTextWidth + 2 || x >= 128 - bwTextWidth - 2))
             continue;
         if (gFrameBuffer[y / 8][x] & (1 << (y % 8)))
             continue;


### PR DESCRIPTION
Hello,
In the spectrum analyzer, the RSSI level trigger line draws over the bandwidth text on the right side. This is because the drawing check was harcoded for the "25k" bw setting, causing "12.5k" and "6.25k" to be ruined.

I fixed it in similar way the scanStep text is handled, located on the left side

## Before
<img width="512" height="320" alt="before" src="https://github.com/user-attachments/assets/7cf1b233-433a-45b8-a6b9-3a857d6f4744" />

## After
<img width="512" height="320" alt="after" src="https://github.com/user-attachments/assets/4f69397a-74e6-4cb9-bc9d-3df5c25e7fa9" />
