### PR TITLE
uart: align UART_DMA_Buffer, it can land next to VCP_ReplyBuf

### DIFF
--- a/App/driver/uart.c
+++ b/App/driver/uart.c
@@ -36,7 +36,9 @@
 #define UART_TX_TIMEOUT_ITERATIONS 10000
 
 static bool UART_IsLogEnabled;
-uint8_t UART_DMA_Buffer[256];
+// Word aligned deliberately: this is the destination of a circular DMA, and it
+// sits immediately before VCP_ReplyBuf in .bss. See the comment in uart.h.
+uint8_t UART_DMA_Buffer[256] __attribute__((aligned(4)));
 
 void UART_Init(void)
 {

--- a/App/driver/uart.h
+++ b/App/driver/uart.h
@@ -21,7 +21,13 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-extern uint8_t UART_DMA_Buffer[256];
+// The alignment is part of the contract, not a hint. UART_DMA_Buffer is the
+// destination of a circular DMA transfer, and the linker places VCP_ReplyBuf
+// directly after it with no padding. If a build shifts this buffer onto an odd
+// address - which any change to the size of a .bss object earlier in the link
+// can do - the transfer runs into the reply buffer and the application stops
+// answering CAT over USB.
+extern uint8_t UART_DMA_Buffer[256] __attribute__((aligned(4)));
 
 void UART_Init(void);
 void UART_Send(const void *pBuffer, uint32_t Size);


### PR DESCRIPTION
`UART_DMA_Buffer` is the destination of a circular DMA transfer, and the linker places `VCP_ReplyBuf` — where CAT replies are assembled — directly after it with no padding. Neither has its alignment pinned, so where the buffer lands depends on the sizes of the `.bss` objects linked before it.

When it lands on an odd address, the application stops answering CAT over USB entirely. Commands still arrive and run (`0x05DD` reboots the radio), the bootloader flashes normally, and the K5 viewer streams the screen over the same endpoint. Only the replies go missing.

Two builds either side of this change, identical in everything else — the gap between the two buffers is zero bytes in both:

```
unaligned:  UART_DMA_Buffer 0x20001e39 + 256 -> ends 0x20001f39, VCP_ReplyBuf 0x20001f39
aligned:    UART_DMA_Buffer 0x20001e3c + 256 -> ends 0x20001f3c, VCP_ReplyBuf 0x20001f3c
```

Only the aligned one answers.

The UART receives into this buffer continuously — the mic connector pin floats when nothing is plugged in — so the transfer runs whether or not a cable is attached.

Stock builds happen to land it on an even address, which is why this has not shown up before. I hit it downstream after removing one entry from `MenuList`: that shrinks `gMenuIndices[ARRAY_SIZE(MenuList)]` by a byte and shifts everything after it down by one.

Background and the full investigation are in the issue.

Fixes #548
