### PR TITLE
Fix EEPROM exclude-flag wipe, dead TX-timeout alert, and two other bugs

### DIFF
--- a/App/audio.c
+++ b/App/audio.c
@@ -360,7 +360,22 @@ uint8_t AUDIO_SetDigitVoice(uint8_t Index, uint16_t Value)
     Count     = 0;
     Result    = Value / 1000U;
     Remainder = Value % 1000U;
-    if (Remainder < 100U)
+
+    if (Result > 0)
+    {
+        // Value has a thousands digit (e.g. channel 1000+ now that this fork
+        // raised MR_CHANNELS_MAX past 999): speak it, then speak the
+        // remaining three digits in full — once a more significant digit has
+        // been spoken, the rest are no longer "leading" and can't be skipped.
+        gVoiceID[gVoiceWriteIndex++] = (VOICE_ID_t)Result;
+        Count++;
+
+        Result = Remainder / 100U;
+        gVoiceID[gVoiceWriteIndex++] = (VOICE_ID_t)Result;
+        Count++;
+        Remainder -= Result * 100U;
+    }
+    else if (Remainder < 100U)
     {
         if (Remainder < 10U)
             goto Skip;

--- a/App/radio.c
+++ b/App/radio.c
@@ -442,7 +442,7 @@ void RADIO_ConfigureChannel(const unsigned int VFO, const unsigned int configure
 
     pVfo->freq_config_RX.Frequency = frequency;
 
-    if (frequency >= frequencyBandTable[BAND2_108MHz].upper && frequency < frequencyBandTable[BAND2_108MHz].upper)
+    if (frequency >= frequencyBandTable[BAND2_108MHz].lower && frequency < frequencyBandTable[BAND2_108MHz].upper)
         pVfo->TX_OFFSET_FREQUENCY_DIRECTION = TX_OFFSET_FREQUENCY_DIRECTION_OFF;
     else if (!IS_MR_CHANNEL(channel))
         pVfo->TX_OFFSET_FREQUENCY = FREQUENCY_RoundToStep(pVfo->TX_OFFSET_FREQUENCY, pVfo->StepFrequency);

--- a/App/scheduler.c
+++ b/App/scheduler.c
@@ -56,7 +56,15 @@ void SysTick_Handler(void)
 
 #ifdef ENABLE_FEAT_F4HWN
         DECREMENT_AND_TRIGGER(gVfoSaveCountdown_10ms, gScheduleVfoSave);
-        DECREMENT_AND_TRIGGER(gTxTimerCountdownAlert_500ms - ALERT_TOT * 2, gTxTimeoutReachedAlert);
+        // Not DECREMENT_AND_TRIGGER: that macro only triggers when the counter
+        // hits exactly zero, but this alert must fire once the counter drops to
+        // (or already starts at or below) the ALERT_TOT*2 threshold, ALERT_TOT
+        // seconds before the real TX timeout in gTxTimerCountdown_500ms.
+        if (gTxTimerCountdownAlert_500ms > 0) {
+            gTxTimerCountdownAlert_500ms--;
+            if (gTxTimerCountdownAlert_500ms <= ALERT_TOT * 2)
+                gTxTimeoutReachedAlert = true;
+        }
         #ifdef ENABLE_FEAT_F4HWN_RX_TX_TIMER
             DECREMENT(gRxTimerCountdown_500ms);
         #endif

--- a/App/settings.c
+++ b/App/settings.c
@@ -410,20 +410,18 @@ gEeprom.FreqChannel[1]   = IS_FREQ_CHANNEL(Data16[5]) ? Data16[5] : (FREQ_CHANNE
     // Init attr cache
     MR_InitChannelAttributesCache();
 
-    // Load and check channel
+    // Load and check channel: only blank/erased attribute slots (__val == 0xFFFF,
+    // i.e. never written) need a sane default. Already-initialized channels must
+    // be left untouched here — this runs on every boot, and clearing `exclude`
+    // unconditionally on the else branch used to silently wipe the user's
+    // "exclude from scan" setting for every channel on every power-on.
     for (uint16_t i = 0; i < MR_CHANNELS_MAX + 7; i++) {
         ChannelAttributes_t *att = MR_GetChannelAttributes(i);
-        
-        if (att != NULL) {
-            if (att->__val == 0xFFFF) {
-                att->__val = 0;
-                att->band = 0x7;
-                MR_SetChannelAttributes(i, att);  // ⭐ IMPORTANT: Sauvegarder!
-            }
-            else {
-                att->exclude = 0;
-                MR_SetChannelAttributes(i, att);  // ⭐ IMPORTANT: Sauvegarder!
-            }
+
+        if (att != NULL && att->__val == 0xFFFF) {
+            att->__val = 0;
+            att->band = 0x7;
+            MR_SetChannelAttributes(i, att);  // ⭐ IMPORTANT: Sauvegarder!
         }
     }
 


### PR DESCRIPTION
Four small, unrelated correctness bugs found during a broader review, grouped together since each is isolated and easy to review independently.

## settings.c — exclude-from-scan flag wiped every boot
`SETTINGS_InitEEPROM()` ran an unconditional loop on every boot that reset every channel's `exclude` (exclude-from-scan) attribute to 0 and wrote it back to flash. Any channel a user excluded from scanning reverted to included on the very next power cycle. Now only blank/erased attribute slots (`__val == 0xFFFF`) are touched; already-initialized channels are left alone.

## scheduler.c — TX-timeout pre-warning could silently never fire
The alert used `DECREMENT_AND_TRIGGER(gTxTimerCountdownAlert_500ms - ALERT_TOT * 2, gTxTimeoutReachedAlert)`, relying on the macro's `--` applying (via operator precedence) only to the counter variable, with the *guard* using the full subtracted expression. For TX-timeout settings <= `ALERT_TOT` seconds (10s) — a valid, selectable minimum in this fork's TOT menu — the guard was false from the very first tick, so the counter never decremented and the alert never fired. Replaced with explicit logic that decrements the real counter every tick and fires once it reaches the alert threshold, working correctly for short timeouts too.

## radio.c — dead band-boundary check (typo)
`RADIO_ConfigureChannel` had:
```c
if (frequency >= frequencyBandTable[BAND2_108MHz].upper && frequency < frequencyBandTable[BAND2_108MHz].upper)
```
`X >= Y && X < Y` can never be true for the same `Y` — clearly a `.lower`/`.upper` typo that made the airband (108-137MHz) TX-offset-clearing safeguard permanently dead code. Fixed to compare against `.lower`/`.upper` respectively, matching the identical pattern used everywhere else in `frequencies.c`.

## audio.c — channel numbers >= 1000 misannounced by voice prompts
`AUDIO_SetDigitVoice` computed the thousands digit (`Value / 1000U`) but immediately discarded it before it was ever queued — only `Value % 1000` was ever spoken. This fork raised `MR_CHANNELS_MAX` to 1024, so selecting a memory channel 1000-1023 with voice prompts enabled announced the wrong number (missing leading digit). Now speaks the thousands digit when present, then the remaining three digits in full (no longer treating them as leading zeros once a more significant digit has been spoken).

## Test plan
- [x] Built the `Transfer` preset via CMake+Ninja — compiles clean, no new warnings, 93% flash.
- [x] Traced each fix against its call sites/callers before applying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)