### PR TITLE
Fix out-of-bounds framebuffer write reachable from normal Breakout play

### DIFF
--- a/App/apps/breakout/breakout_app.c
+++ b/App/apps/breakout/breakout_app.c
@@ -129,8 +129,8 @@ static void drawBall(void) {
     ball.x += ball.dx; ball.y += ball.dy;
 
     if (ball.y <= 0)        { ball.dx = randInt(-3, 3); ball.dy = 1; }
-    else if (ball.x <= 2)   { ball.dx = iabs(ball.dx); }
-    else if (ball.x >= 124) { ball.dx = -iabs(ball.dx); }
+    else if (ball.x <= 2)   { ball.x = 2;   ball.dx = iabs(ball.dx); }
+    else if (ball.x >= 124) { ball.x = 124; ball.dx = -iabs(ball.dx); }
 
     if (ball.y == 47) {
         if (ball.x + 1 >= racket.x && ball.x - 1 <= racket.x + RACKET_WIDTH) {

--- a/App/ui/helper.c
+++ b/App/ui/helper.c
@@ -235,6 +235,13 @@ void UI_DisplayFrequency(const char *string, uint8_t X, uint8_t Y, bool center)
 
 void UI_DrawPixelBuffer(uint8_t (*buffer)[128], uint8_t x, uint8_t y, bool black)
 {
+    // x/y can arrive here already wrapped from a negative or out-of-range
+    // caller coordinate narrowed to uint8_t (e.g. UI_DrawLineBuffer takes
+    // int16_t); without this check that silently corrupts memory beyond
+    // gFrameBuffer[FRAME_LINES][128].
+    if (x >= LCD_WIDTH || y >= FRAME_LINES * 8)
+        return;
+
     const uint8_t pattern = 1 << (y % 8);
     if(black)
         buffer[y/8][x] |= pattern;


### PR DESCRIPTION
## Summary
`UI_DrawPixelBuffer(uint8_t (*buffer)[128], uint8_t x, uint8_t y, ...)` took `x`/`y` with no range check. `UI_DrawLineBuffer` (which backs the overlay-app `draw_line`/`draw_rect` API) takes *signed* `int16_t` coordinates, and a negative value silently narrows to a large `uint8_t` when passed through (e.g. `-1` -> `255`), indexing far outside `gFrameBuffer[7][128]`.

This is concretely reachable from normal gameplay, not just a hypothetical: Breakout's `drawBall()` updates `ball.x` *before* reacting to the wall, so for one frame `ball.x` can legitimately be `0`, `1`, or slightly negative, and `renderBall()` draws at `ball.x - 1` — going out of bounds every time the ball bounces off the left (or, symmetrically, the right) wall. Other games in the same overlay-app framework (`tetris_app.c`, `cube3d_app.c`) bounds-check their own pixel setters; this shared primitive didn't.

## Fix
Fixed at both layers:
- `UI_DrawPixelBuffer` now bounds-checks `x`/`y` before writing, protecting any current or future caller of the shared drawing primitives.
- `breakout_app.c` now clamps `ball.x` to the wall on bounce, which also fixes the underlying visual glitch (ball briefly drawn off-screen) rather than just its memory-safety symptom.

## Test plan
- [x] Rebuilt the `Labs` preset (the one that actually links `ui/helper.c` as the overlay-app host) via CMake+Ninja — compiles clean.
- [x] Rebuilt the `Breakout` overlay app via `compile-app.sh breakout` (Docker) — 2560 B / 62.5% of its 4 KiB budget, comfortable headroom for the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)