### PR TITLE
Bound SPI/DMA waits, fix bk4819 register-cache skip, mark dead drivers

### DIFF
--- a/App/driver/adc.c
+++ b/App/driver/adc.c
@@ -14,6 +14,15 @@
  *     limitations under the License.
  */
 
+/* DEAD CODE / NOT BUILT: this file is not listed in App/CMakeLists.txt and is
+ * not compiled into any firmware preset. It targets the SARADC peripheral of
+ * the original DP32G030 chip via bsp/dp32g030/*.h headers that no longer
+ * exist in this repository, from before this fork moved to PY32F071-based
+ * hardware — it cannot even compile as-is. Kept only for historical
+ * reference; do not rely on the register shift/mask values below (see the
+ * comment on FW_R_SARADC_SMPL_SHIFT, which the code itself flags as
+ * possibly wrong against the DP32G030 TRM). */
+
 #include "ARMCM0.h"
 #include "adc.h"
 #include "bsp/dp32g030/irq.h"

--- a/App/driver/adc.h
+++ b/App/driver/adc.h
@@ -14,6 +14,10 @@
  *     limitations under the License.
  */
 
+/* DEAD CODE / NOT BUILT: interface for driver/adc.c, which is not part of
+ * this fork's build (see the note at the top of that file). Not included by
+ * any compiled source. Kept only for historical reference. */
+
 #ifndef DRIVER_ADC_H
 #define DRIVER_ADC_H
 

--- a/App/driver/bk4829.c
+++ b/App/driver/bk4829.c
@@ -1096,6 +1096,11 @@ void BK4819_PlaySingleTone(const unsigned int tone_Hz, const unsigned int delay,
     }
 
     BK4819_WriteRegister(BK4819_REG_70, 0x0000);
+    // Reset to 0 first (as other REG_30 writers do) so this always goes
+    // through a real 0->pattern transition and retriggers VCO calibration,
+    // even if the write-cache already holds 0xC1FE from a prior tone/DTMF
+    // call with nothing else touching REG_30 in between.
+    BK4819_WriteRegister(BK4819_REG_30, 0);
     BK4819_WriteRegister(BK4819_REG_30, 0xC1FE);
     BK4819_ExitTxMute();
 }
@@ -1308,6 +1313,9 @@ void BK4819_ExitDTMF_TX(bool bKeep)
     BK4819_SetAF(BK4819_AF_MUTE);
     BK4819_WriteRegister(BK4819_REG_70, 0x0000);
     BK4819_DisableDTMF();
+    // See BK4819_PlaySingleTone: reset to 0 first so this write can't be
+    // silently skipped by the REG_30 write-cache.
+    BK4819_WriteRegister(BK4819_REG_30, 0);
     BK4819_WriteRegister(BK4819_REG_30, 0xC1FE);
     if (!bKeep)
         BK4819_ExitTxMute();

--- a/App/driver/eeprom.c
+++ b/App/driver/eeprom.c
@@ -14,6 +14,14 @@
  *     limitations under the License.
  */
 
+/* DEAD CODE / NOT BUILT: this file is not listed in App/CMakeLists.txt and is
+ * not compiled into any firmware preset. It targets an external I2C EEPROM
+ * chip, from the original DP32G030-based hardware this fork no longer
+ * targets. The active implementation of the EEPROM_ReadBuffer/WriteBuffer
+ * interface declared in driver/eeprom.h is driver/eeprom_compat.c, which is
+ * backed by the SPI NOR flash driver (driver/py25q16.c) on this fork's
+ * PY32F071-based hardware. Kept only for historical reference. */
+
 #include <stddef.h>
 #include <string.h>
 

--- a/App/driver/py25q16.c
+++ b/App/driver/py25q16.c
@@ -42,6 +42,13 @@
 #define SECTOR_SIZE 0x1000
 #define PAGE_SIZE 0x100
 
+/* Bounded wait for the DMA1 transfer-complete IRQ (sets TC_Flag) that follows
+ * SPI_ReadBuf/SPI_WriteBuf. There is no hardware watchdog in this firmware, so
+ * an unbounded wait here would freeze the radio forever if that interrupt is
+ * ever missed (bus glitch, mis-armed channel, SPI stall). A full SECTOR_SIZE
+ * transfer normally completes in a few ms; this generously overshoots that. */
+#define SPI_DMA_TIMEOUT 2000000u
+
 static uint32_t SectorCacheAddr = 0x1000000;
 #ifdef ENABLE_FEAT_F4HWN_MULTIBOOT_OVERLAY
 /* The restore-only RAM stub is copied over this cache immediately before it
@@ -184,8 +191,14 @@ static void SPI_ReadBuf(uint8_t *Buf, uint32_t Size)
     LL_SPI_Enable(SPIx);
     LL_SPI_EnableDMAReq_TX(SPIx);
 
-    while (!TC_Flag)
+    uint32_t timeout = SPI_DMA_TIMEOUT;
+    while (!TC_Flag && --timeout)
         ;
+    if (!TC_Flag) {
+        LL_DMA_DisableChannel(DMA1, CHANNEL_RD);
+        LL_DMA_DisableChannel(DMA1, CHANNEL_WR);
+        LL_SPI_Disable(SPIx);
+    }
 }
 
 static void SPI_WriteBuf(const uint8_t *Buf, uint32_t Size)
@@ -233,8 +246,14 @@ static void SPI_WriteBuf(const uint8_t *Buf, uint32_t Size)
     LL_SPI_Enable(SPIx);
     LL_SPI_EnableDMAReq_TX(SPIx);
 
-    while (!TC_Flag)
+    uint32_t timeout = SPI_DMA_TIMEOUT;
+    while (!TC_Flag && --timeout)
         ;
+    if (!TC_Flag) {
+        LL_DMA_DisableChannel(DMA1, CHANNEL_RD);
+        LL_DMA_DisableChannel(DMA1, CHANNEL_WR);
+        LL_SPI_Disable(SPIx);
+    }
 }
 
 static uint8_t SPI_WriteByte(uint8_t Value)


### PR DESCRIPTION
## py25q16.c — unbounded SPI/DMA busy-wait
`SPI_ReadBuf`/`SPI_WriteBuf` spun on `while (!TC_Flag);` with no timeout, waiting for the DMA1 transfer-complete IRQ. There is no hardware watchdog anywhere in this firmware, so a missed/failed DMA interrupt (bus glitch, mis-armed channel, SPI stall) would hang the radio permanently on any flash access. Added a bounded timeout modeled directly on `mb_flash.c`'s existing "a wedged SPI can never freeze the firmware" pattern; on timeout the DMA channels and SPI are disabled instead of spinning forever.

## bk4829.c — register write-cache can skip a needed write
`BK4819_PlaySingleTone` and `BK4819_ExitDTMF_TX` wrote `REG_30` directly to a literal value (`0xC1FE`) with no preceding reset, unlike every other `REG_30` writer in this file. The `REG_30` write-cache added to this driver skips a write when the value is unchanged from the cache, so if the cache already held `0xC1FE` from a prior tone/DTMF call, the write — and the VCO recalibration it's meant to retrigger via a real 0->1 transition on bit 15 (`BK4819_REG_30_ENABLE_VCO_CALIB`) — was silently skipped. Both now reset `REG_30` to 0 first, matching the reset-then-set convention used by every other call site.

## adc.c/adc.h, eeprom.c — marked as dead code (left in place)
Neither file is listed in `App/CMakeLists.txt`'s source list (which is fully explicit — no glob patterns are used anywhere in this build), so neither compiles into any firmware preset:
- `adc.c` targets the SARADC peripheral of the original DP32G030 chip via `bsp/dp32g030/*.h` headers that no longer exist anywhere in this repository — it can't even compile as-is.
- `eeprom.c` targets an external I2C EEPROM chip and has been superseded by `eeprom_compat.c` (backed by the SPI NOR flash driver, `py25q16.c`) on this fork's PY32F071-based hardware. `eeprom.h` (the shared interface) is still very much alive and used elsewhere — only the I2C implementation in `eeprom.c` is dead.

Left in place rather than deleted, per maintainer preference, with a comment at the top of each file explaining why — for historical reference and so nobody spends time debugging code that never runs.

## Test plan
- [x] Rebuilt the `Transfer` preset via CMake+Ninja after both driver fixes — compiles clean, no new warnings.
- [x] Confirmed via `grep`/`git ls-files` that `adc.c`/`eeprom.c` are absent from every build's source list and unreachable from any compiled file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)